### PR TITLE
Added credentials needed for Docker Hub cache to work

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -10,6 +10,11 @@ echo "> Setting up website skeleton"
 PROJECT_BUILD_DIR=${HOME}/build/project
 composer create-project ibexa/website-skeleton ${PROJECT_BUILD_DIR} --no-install --no-scripts 
 
+if [[ -n "${DOCKER_PASSWORD}" ]]; then
+    echo "> Set up Docker credentials"
+    echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+fi
+
 # Create container to install dependencies
 docker run --name install_dependencies -d --volume=${PROJECT_BUILD_DIR}:/var/www:cached --volume=${HOME}/.composer:/root/.composer -e APP_ENV -e APP_DEBUG ${PHP_IMAGE}
 


### PR DESCRIPTION
Adding missing Docker credentials setup (taken from https://github.com/ezsystems/ezplatform/blob/master/bin/.travis/trusty/setup_ezplatform.sh).

This part is currently missing and results in build failures, as in https://travis-ci.org/github/ezsystems/ezplatform-user/jobs/760298759 :
```
7.3-v2-node12: Pulling from ezsystems/php

anyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
```