### PR TITLE
Changed BehatBundle version to dev

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -67,8 +67,9 @@ composer config repositories.localDependency "$JSON_STRING"
 docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION}
 
-# Install packages required for testing
-docker exec install_dependencies composer require --dev ezsystems/behatbundle --no-scripts
+# Install packages required for testing - disabled prefer-stable so that @dev can be used
+docker exec install_dependencies composer config prefer-stable false
+docker exec install_dependencies composer require --dev ezsystems/behatbundle:*@dev --no-scripts
 docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
 
 # Init a repository to avoid Composer asking questions


### PR DESCRIPTION
We should be installing the dev version of BehatBundle, otherwise we will have to tag it after every PR (not ideal).
I had to set prefer-stable to false, otherwise it's impossible to install a dev version without hacks (it's enabled by default in the website-skeleton: https://github.com/ibexa/website-skeleton/blob/main/composer.json#L7)

You can see in https://github.com/ezsystems/ezcommerce-order-history/pull/23 (Travis: https://travis-ci.com/github/ezsystems/ezcommerce-order-history/jobs/489692618) that the setup passes correctly and BehatBundle:dev-master is used.