### PR TITLE
Made Composer update all dependencies when ibexa/<edition> package is requested

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -65,7 +65,7 @@ composer config repositories.localDependency "$JSON_STRING"
 
 # Install correct product variant
 docker exec install_dependencies composer update
-docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION}
+docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W
 
 # Install packages required for testing - disabled prefer-stable so that @dev can be used
 docker exec install_dependencies composer config prefer-stable false


### PR DESCRIPTION
Related PR:
https://github.com/ibexa/oss/pull/4

After we've added a conflict with Symfony version we need to add the `-W` switch so that ibexa/oss can influence the already installed packages (installing from website-skeleton creates a composer.lock file).