### PR TITLE
IBX-115: Added tools to run regression on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor/
+composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,8 @@
+<?php
+return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/src')
+            ->files()->name('*.php')
+    )
+;

--- a/bin/travis
+++ b/bin/travis
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$application = new Symfony\Component\Console\Application;
+
+$application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\LinkDependenciesCommand());
+$application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\RunRegressionCommand());
+$application->setDefaultCommand('dependencies:link');
+
+$application->run();

--- a/bin/travis
+++ b/bin/travis
@@ -24,6 +24,5 @@ $application = new Symfony\Component\Console\Application;
 
 $application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\LinkDependenciesCommand());
 $application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\RunRegressionCommand());
-$application->setDefaultCommand('dependencies:link');
 
 $application->run();

--- a/bin/travis
+++ b/bin/travis
@@ -1,7 +1,24 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
+    require $autoload;
+}
+
+if (!class_exists('Symfony\Component\Console\Application', true)) {
+    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
+        require($autoload);
+    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
+        require($autoload);
+    } else {
+        fwrite(STDERR,
+            'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+            'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+            'php composer.phar install'.PHP_EOL
+        );
+        exit(1);
+    }
+}
 
 $application = new Symfony\Component\Console\Application;
 

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,42 @@
     "type": "library",
     "license": "GPL-2.0-only",
     "minimum-stability": "stable",
-    "require": {},
+    "require": {
+        "php": "^7.3",
+        "ext-json": "*",
+        "symfony/console": "^5.2",
+        "symfony/serializer": "^5.2",
+        "symfony/property-access": "^5.2",
+        "czproject/git-php": "^3.18",
+        "knplabs/github-api": "^3.0",
+        "php-http/guzzle6-adapter": "^2.0",
+        "guzzlehttp/guzzle": "^6.5",
+        "symfony/filesystem": "^5.0",
+        "http-interop/http-factory-guzzle": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ibexa\\Platform\\ContiniousIntegrationScripts\\": "src/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "0.1.x-dev"
         }
     },
-    "bin": ["bin/check_cs.sh", "bin/prepare_project_edition.sh", "bin/update_docker.sh"]
+    "bin": [
+        "bin/check_cs.sh",
+        "bin/prepare_project_edition.sh",
+        "bin/update_docker.sh",
+        "bin/travis"
+    ],
+    "require-dev": {
+        "ezsystems/ezplatform-code-style": "^1.0@dev",
+        "phpstan/phpstan": "~0.12"
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.neon",
+        "phpstan-baseline": "phpstan analyse -c phpstan.neon --generate-baseline",
+        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating"
+    }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,22 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Offset 'head' does not exist on array\\|string\\.$#"
+			count: 2
+			path: src/Command/LinkDependenciesCommand.php
+
+		-
+			message: "#^Property Ibexa\\\\Platform\\\\ContiniousIntegrationScripts\\\\Command\\\\LinkDependenciesCommand\\:\\:\\$token \\(string\\|null\\) does not accept array\\<string\\>\\|string\\|null\\.$#"
+			count: 1
+			path: src/Command/LinkDependenciesCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$productVersion of method Ibexa\\\\Platform\\\\ContiniousIntegrationScripts\\\\Command\\\\RunRegressionCommand\\:\\:mapProductVersionToPageBuilder\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Command/RunRegressionCommand.php
+
+		-
+			message: "#^Property Ibexa\\\\Platform\\\\ContiniousIntegrationScripts\\\\Command\\\\RunRegressionCommand\\:\\:\\$token \\(string\\|null\\) does not accept array\\<string\\>\\|string\\|null\\.$#"
+			count: 1
+			path: src/Command/RunRegressionCommand.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 7
+    paths:
+        - src

--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -70,6 +70,10 @@ class LinkDependenciesCommand extends Command
         preg_match('/.*github.com\/(.*)\/(.*)\/pull\/(\d+).*/', $pullRequestURL, $matches);
         [, $owner, $repository, $prNumber] = $matches;
 
+        if ($repository === "recipes") {
+            throw new \RuntimeException('Symfony Flex recipes are not supported as dependencies. Please consult QA team what can be done in this case.');
+        }
+
         $client = new Client();
         if ($this->token) {
             $client->authenticate($this->token, null, Client::AUTH_ACCESS_TOKEN);

--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -84,8 +84,9 @@ class LinkDependenciesCommand extends Command
         $pullRequestData = new ComposerPullRequestData();
         $pullRequestData->repositoryUrl = $pullRequestDetails['head']['repo']['html_url'];
         $branchName = $pullRequestDetails['head']['ref'];
+        $targetBranch = $pullRequestDetails['base']['ref'];
 
-        $composerData = json_decode($client->repos()->contents()->download($owner, $repository, 'composer.json'), true);
+        $composerData = json_decode($client->repos()->contents()->download($owner, $repository, 'composer.json', $targetBranch), true);
 
         $aliases = array_keys($composerData['extra']['branch-alias']);
         $branchAlias = $composerData['extra']['branch-alias'][$aliases[0]];

--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\ContiniousIntegrationScripts\Command;
+
+use Github\Client;
+use Ibexa\Platform\ContiniousIntegrationScripts\Helper\ComposerHelper;
+use Ibexa\Platform\ContiniousIntegrationScripts\ValueObject\ComposerPullRequestData;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class LinkDependenciesCommand extends Command
+{
+    public const DEPENDENCIES_FILE = 'dependencies.json';
+
+    /** @var ?string */
+    private $token;
+
+    /** @var \Symfony\Component\Serializer\Serializer */
+    private $serializer;
+
+    /** @var string[] */
+    private $pullRequestUrls;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $this->token = $input->getArgument('token');
+
+        $pullRequestsData = [];
+        foreach ($this->pullRequestUrls as $pullRequestUrl) {
+            $pullRequestsData[] = $this->getPullRequestData($pullRequestUrl);
+        }
+
+        $this->createDependenciesFile($pullRequestsData, $io);
+
+        return Command::SUCCESS;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('dependencies:link')
+            ->setDescription(sprintf('Outputs a %s file that contains data about related Pull Requests', self::DEPENDENCIES_FILE))
+            ->addArgument('token', InputArgument::OPTIONAL, 'GitHub OAuth token')
+        ;
+    }
+
+    private function getPullRequestData(string $pullRequestURL): ComposerPullRequestData
+    {
+        $matches = [];
+        preg_match('/.*github.com\/(.*)\/(.*)\/pull\/(\d+).*/', $pullRequestURL, $matches);
+        [, $owner, $repository, $prNumber] = $matches;
+
+        $client = new Client();
+        if ($this->token) {
+            $client->authenticate($this->token, null, Client::AUTH_ACCESS_TOKEN);
+        }
+
+        $pullRequestDetails = $client->pullRequests()->show($owner, $repository, $prNumber);
+
+        $pullRequestData = new ComposerPullRequestData();
+        $pullRequestData->repositoryUrl = $pullRequestDetails['head']['repo']['html_url'];
+        $branchName = $pullRequestDetails['head']['ref'];
+
+        $composerData = json_decode($client->repos()->contents()->download($owner, $repository, 'composer.json'), true);
+
+        $aliases = array_keys($composerData['extra']['branch-alias']);
+        $branchAlias = $composerData['extra']['branch-alias'][$aliases[0]];
+
+        $pullRequestData->package = $composerData['name'];
+        $pullRequestData->requirement = sprintf('dev-%s as %s', $branchName, $branchAlias);
+
+        return $pullRequestData;
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$input->getArgument('token')) {
+            $input->setArgument('token', ComposerHelper::getGitHubToken());
+        }
+
+        $relatedPRsNumber = $io->ask('Please enter the number of related Pull Requests', '1', static function ($number) {
+            if (!is_numeric($number) || $number < 1) {
+                throw new \RuntimeException('Positive integer expected.');
+            }
+
+            return (int) $number;
+        });
+
+        $pullRequestUrls = [];
+        for ($i = 0; $i < $relatedPRsNumber; ++$i) {
+            $pullRequestUrls[] = $io->ask('Link to GitHub PR', null, static function ($answer) {
+                if (!is_string($answer) || !str_contains($answer, 'github.com')) {
+                    throw new \RuntimeException(
+                        'Link to Pull Request on GitHub expected. Example: https://github.com/ibexa/recipes/pull/22'
+                    );
+                }
+
+                return $answer;
+            });
+        }
+
+        $this->pullRequestUrls = array_unique($pullRequestUrls);
+    }
+
+    /**
+     * @param \Ibexa\Platform\ContiniousIntegrationScripts\ValueObject\ComposerPullRequestData[] $pullRequestsData
+     */
+    private function createDependenciesFile(array $pullRequestsData, SymfonyStyle $io): void
+    {
+        $jsonContent = $this->serializer->serialize($pullRequestsData, 'json', ['json_encode_options' => JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT]);
+        file_put_contents(self::DEPENDENCIES_FILE, $jsonContent);
+        $io->success(sprintf('Successfully generated %s file', self::DEPENDENCIES_FILE));
+    }
+}

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -42,7 +42,7 @@ class RunRegressionCommand extends Command
                 if (preg_match('/^(\d+)\.(\d+)$/', $answer) === 0) {
                     throw new \RuntimeException(
                         sprintf(
-                            'Unregognised version format: %s. Please use format X.Y instead, e.g. 3.3',
+                            'Unrecognised version format: %s. Please use format X.Y instead, e.g. 3.3',
                         $answer)
                     );
                 }

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -120,7 +120,7 @@ class RunRegressionCommand extends Command
     {
         if (!file_exists(LinkDependenciesCommand::DEPENDENCIES_FILE)) {
             throw new \RuntimeException(
-                sprintf("File '%s' not found. Please run `php bin/travis dependencies:link` before running this Command", LinkDependenciesCommand::DEPENDENCIES_FILE)
+                sprintf("File '%s' not found. Please run the `dependencies:link` before running this Command", LinkDependenciesCommand::DEPENDENCIES_FILE)
             );
         }
 

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -39,7 +39,7 @@ class RunRegressionCommand extends Command
 
         if (!$input->getArgument('productVersion')) {
             $productVersion = $io->ask('Please enter the Ibexa DXP version', '3.3', static function (string $answer): string {
-                if (preg_match('/(\d+)\.(\d+)/', $answer) === 0) {
+                if (preg_match('/^(\d+)\.(\d+)$/', $answer) === 0) {
                     throw new \RuntimeException(
                         sprintf(
                             'Unregognised version format: %s. Please use format X.Y instead, e.g. 3.3',

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\ContiniousIntegrationScripts\Command;
+
+use Cz\Git\GitRepository;
+use Github\Client;
+use Ibexa\Platform\ContiniousIntegrationScripts\Helper\ComposerHelper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+
+class RunRegressionCommand extends Command
+{
+    private const REPO_OWNER = 'mnocon';
+
+    private const REPO_NAME = 'ezplatform-page-builder';
+
+    private const COMMIT_MESSAGE = '[TMP] Run Regression';
+
+    /** @var ?string */
+    private $token;
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$input->getArgument('token')) {
+            $input->setArgument('token', ComposerHelper::getGitHubToken());
+        }
+
+        if (!$input->getArgument('productVersion')) {
+            $productVersion = $io->ask('Please enter the Ibexa DXP version', '3.3', static function (string $answer): string {
+                if (preg_match('/(\d+)\.(\d+)/', $answer) === 0) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'Unregognised version format: %s. Please use format X.Y instead, e.g. 3.3',
+                        $answer)
+                    );
+                }
+
+                return $answer;
+            });
+
+            $input->setArgument('productVersion', $productVersion);
+        }
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->token = $input->getArgument('token');
+        $productVersion = $input->getArgument('productVersion');
+
+        $this->validate();
+
+        $pageBuilderBaseBranch = $this->mapProductVersionToPageBuilder($productVersion);
+        $regressionBranchName = uniqid('tmp_regression_', true);
+
+        $repo = GitRepository::cloneRepository(
+            sprintf('https://github.com/%s/%s.git', self::REPO_OWNER, self::REPO_NAME),
+            null, ['-b' => $pageBuilderBaseBranch]
+        );
+        $repo->createBranch($regressionBranchName, true);
+        $repo->removeBranch($pageBuilderBaseBranch);
+
+        copy(LinkDependenciesCommand::DEPENDENCIES_FILE, self::REPO_NAME . \DIRECTORY_SEPARATOR . LinkDependenciesCommand::DEPENDENCIES_FILE);
+
+        $repo->addFile('dependencies.json');
+        $repo->commit(self::COMMIT_MESSAGE);
+        $repo->push('origin', [$regressionBranchName, '-u']);
+
+        $io->success(sprintf('Successfuly pushed to %s/%s a branch called: %s', self::REPO_OWNER, self::REPO_NAME, $regressionBranchName));
+
+        $client = new Client();
+        if ($this->token) {
+            $client->authenticate($this->token, null, Client::AUTH_ACCESS_TOKEN);
+        }
+
+        $this->waitUntilBranchExists($client, $regressionBranchName);
+
+        $response = $client->pullRequests()->create(self::REPO_OWNER, self::REPO_NAME,
+        [
+            'title' => 'Run regression for IBX-XXXX',
+            'base' => $pageBuilderBaseBranch,
+            'head' => $regressionBranchName,
+            'body' => 'Please add your description here.',
+            'draft' => 'true',
+        ]);
+
+        $io->success(sprintf('Created PR, please see: %s', $response['_links']['html']['href']));
+
+        if ($io->confirm(sprintf('Do you want to remove the created %s directory?', self::REPO_NAME), true)) {
+            $fs = new Filesystem();
+            $fs->remove(self::REPO_NAME);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('regression:run')
+            ->setDescription('Triggers a regression run on Travis')
+            ->addArgument('productVersion', InputArgument::REQUIRED, 'Ibexa DXP version')
+            ->addArgument('token', InputArgument::OPTIONAL, 'GitHub token')
+        ;
+    }
+
+    private function validate(): void
+    {
+        if (!file_exists(LinkDependenciesCommand::DEPENDENCIES_FILE)) {
+            throw new \RuntimeException(
+                sprintf("File '%s' not found. Please run `php bin/travis dependencies:link` before running this Command", LinkDependenciesCommand::DEPENDENCIES_FILE)
+            );
+        }
+
+        $dependenciesFile = file_get_contents(LinkDependenciesCommand::DEPENDENCIES_FILE);
+        if ($dependenciesFile === false) {
+            throw new \RuntimeException(
+                sprintf('Unable to read the %s file', LinkDependenciesCommand::DEPENDENCIES_FILE)
+            );
+        }
+
+        $dependencies = json_decode($dependenciesFile, true, 512, JSON_THROW_ON_ERROR);
+
+        foreach ($dependencies as $dependency) {
+            if ($dependency['package'] === 'ezsystems/ezplatform-page-builder') {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Page Builder dependency detected. Simply attach the %s file to that PR and use the commit messgae "%s"',
+                        LinkDependenciesCommand::DEPENDENCIES_FILE,
+                        self::COMMIT_MESSAGE
+                    )
+                );
+            }
+        }
+    }
+
+    private function mapProductVersionToPageBuilder(string $productVersion): string
+    {
+        switch ($productVersion) {
+            case '3.3':
+                return 'master';
+            case '2.5':
+            case '3.2':
+            default:
+                throw new \RuntimeException(
+                    sprintf(
+                        'Unsupported version %s. Please contact QA team',
+                        $productVersion
+                    ));
+        }
+    }
+
+    private function waitUntilBranchExists(Client $client, string $branchNme): void
+    {
+        $counter = 0;
+        $success = false;
+        while ($counter < 5) {
+            try {
+                $client->repo()->branches(self::REPO_OWNER, self::REPO_NAME, $branchNme);
+                $success = true;
+                break;
+            } catch (\RuntimeException $e) {
+                sleep(1);
+                ++$counter;
+            }
+        }
+
+        if (!$success) {
+            throw new \RuntimeException('Pushed branch not found using GitHub API.');
+        }
+    }
+}

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -120,7 +120,7 @@ class RunRegressionCommand extends Command
     {
         if (!file_exists(LinkDependenciesCommand::DEPENDENCIES_FILE)) {
             throw new \RuntimeException(
-                sprintf("File '%s' not found. Please run the `dependencies:link` before running this Command", LinkDependenciesCommand::DEPENDENCIES_FILE)
+                sprintf("File '%s' not found. Please run the `dependencies:link` Command before running this one.", LinkDependenciesCommand::DEPENDENCIES_FILE)
             );
         }
 

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class RunRegressionCommand extends Command
 {
-    private const REPO_OWNER = 'mnocon';
+    private const REPO_OWNER = 'ezsystems';
 
     private const REPO_NAME = 'ezplatform-page-builder';
 
@@ -150,6 +150,8 @@ class RunRegressionCommand extends Command
     {
         switch ($productVersion) {
             case '3.3':
+                return '2.3';
+            case '4.0':
                 return 'master';
             case '2.5':
             case '3.2':

--- a/src/Helper/ComposerHelper.php
+++ b/src/Helper/ComposerHelper.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\ContiniousIntegrationScripts\Helper;
+
+class ComposerHelper
+{
+    public static function getGitHubToken(): ?string
+    {
+        $output = [];
+        $result_code = 0;
+        exec('composer config github-oauth.github.com --global 2> /dev/null', $output, $result_code);
+
+        return $result_code === 0 ? $output[0] : null;
+    }
+}

--- a/src/ValueObject/ComposerPullRequestData.php
+++ b/src/ValueObject/ComposerPullRequestData.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\ContiniousIntegrationScripts\ValueObject;
+
+class ComposerPullRequestData
+{
+    /** @var string */
+    public $requirement;
+
+    /** @var string */
+    public $repositoryUrl;
+
+    /** @var string */
+    public $package;
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-115

On Symfony Flex editions Travis supports adding new dependencies by adding a `dependencies.json` file specyfing them (see https://github.com/ibexa/ci-scripts/pull/5), for example:
```
[
    {
        "repositoryUrl": "https://github.com/ezsystems/BehatBundle.git",
        "package": " ezsystems/behatbundle",
        "requirement": "dev-add-edition-specific-configs as 8.3.x-dev"
    },
    {
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-page-builder.git",
        "package": " ezsystems/ezplatform-page-builder",
        "requirement": "dev-MY_TEST_BRANCH as 2.3.x-dev"
    }
]
```

This PR adds two Commands:
1) `bin/travis dependencies:link` to create the `dependencies.json` file
2) `bin/travis regression:run` to use the `dependencies.json` file and run a larger test suite on Travis

## Linking dependencies
Example usage:
```
MacBook-Pro:ci-scripts mareknocon$ bin/travis dependencies:link

 Please enter the number of related Pull Requests [1]:
 > 1

 Link to GitHub PR:
 > https://github.com/ezsystems/ezplatform-kernel/pull/173

 [OK] Successfully generated dependencies.json file
```

And the result dependencies.json looks like this:
```
MacBook-Pro:ci-scripts mareknocon$ cat dependencies.json
[
    {
        "requirement": "dev-switch-travis-to-symfony-flex as 1.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-kernel",
        "package": "ezsystems/ezplatform-kernel"
    }
]
```

This file can be commited as TMP commit and Travis will use it.

Other potential usage:
- given a file "test" with content:
```
5
https://github.com/ezsystems/ezplatform-kernel/pull/173
https://github.com/ibexa/ci-scripts/pull/7
https://github.com/ibexa/docker/pull/3
https://github.com/ezsystems/BehatBundle/pull/177
https://github.com/ezsystems/ezplatform-site-factory/pull/116
```

Usage:
```
MacBook-Pro:ci-scripts mareknocon$ cat test | bin/travis dependencies:link

 Please enter the number of related Pull Requests [1]:
 >
 Link to GitHub PR:
 >
 Link to GitHub PR:
 >
 Link to GitHub PR:
 >
 Link to GitHub PR:
 >
 Link to GitHub PR:
 >


 [OK] Successfully generated dependencies.json file
```
Result `dependencies.json`:
```
[
    {
        "requirement": "dev-switch-travis-to-symfony-flex as 1.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-kernel",
        "package": "ezsystems/ezplatform-kernel"
    },
    {
        "requirement": "dev-execute-dependencies-recipes as 0.1.x-dev",
        "repositoryUrl": "https://github.com/ibexa/ci-scripts",
        "package": "ibexa/ci-scripts"
    },
    {
        "requirement": "dev-add-sitefactory-setup as 0.1.x-dev",
        "repositoryUrl": "https://github.com/ibexa/docker",
        "package": "ibexa/docker"
    },
    {
        "requirement": "dev-add-sitefactory-setup as 8.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/BehatBundle",
        "package": "ezsystems/behatbundle"
    },
    {
        "requirement": "dev-add-sitefactory-setup as 1.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-site-factory",
        "package": "ezsystems/ezplatform-site-factory"
    }
]
```

## Running regression

This Command triggers a build on Travis using the specified dependencies.json file.
Usage:
```
MacBook-Pro:ci-scripts mareknocon$ bin/travis regression:run

 Please enter the Ibexa DXP version [3.3]:
 >



 [OK] Successfuly pushed to mnocon/ezplatform-page-builder a branch called: tmp_regression_607eb13eaaeea8.24772576



 [OK] Created PR, please see: https://github.com/mnocon/ezplatform-page-builder/pull/22


 Do you want to remove the created ezplatform-page-builder directory? (yes/no) [yes]:
 > yes
```

Please see the result at https://github.com/mnocon/ezplatform-page-builder/pull/22

## Potential issues
I'm afraif that there might be issues with how GitHub is accessed (HTTPS/SSH etc.), so we need to test it on different machines.

## How to install
The Commands should be installed automatically by running `composer install` inside any package that contains it in require-dev section (all of the ones with Travis setup, for example: https://github.com/ezsystems/ezplatform-admin-ui/blob/master/composer.json#L51). It will be available as Composer binary, which means you can start it by running:
`vendor/bin/travis` (unless bin-dir has bin configured differently) from the package where it's added as dependency.

You can also set it up in standalone mode by running `composer create-project ibexa/ci-scripts:dev-add-regression-tool`.
Then you can start it by running `bin/travis`.

## TODO before merging.
Change the owner from `mnocon` to `ezsystems`.