### PR TITLE
[Travis] Switched the default PHP version to 7.4

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -4,7 +4,7 @@ set -e
 PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 COMPOSE_FILE=$3
-PHP_IMAGE=${4-ezsystems/php:7.3-v2-node12}
+PHP_IMAGE=${4-ezsystems/php:7.4-v2-node12}
 
 echo "> Setting up website skeleton"
 PROJECT_BUILD_DIR=${HOME}/build/project


### PR DESCRIPTION
Version 4.0 of our product will require at least PHP 7.4 and some packages are already enforcing it:
https://github.com/ezsystems/ezplatform-personalization/pull/201

This makes it impossible to install it when running on PHP 7.3.

This PR bumps the default version to 7.4.

Example Travis failure:
https://travis-ci.com/ezsystems/ezplatform-page-builder/builds/224919398?utm_source=slack&utm_medium=notification
```
 Problem 1
    - ezsystems/ezplatform-personalization dev-master requires php ^7.4 -> your php version (7.3.27) does not satisfy that requirement.
    - ibexa/content 4.0.x-dev is an alias of ibexa/content dev-master and thus requires it to be installed too.
    - ibexa/experience dev-master requires ibexa/content ^4.0.x-dev -> satisfiable by ibexa/content[4.0.x-dev (alias of dev-master)].
    - ibexa/content dev-master requires ezsystems/ezplatform-personalzation ^2.0.x-dev -> satisfiable by ezsystems/ezplatform-personalization[2.0.x-dev (alias of dev-master)].
    - ibexa/experience 4.0.x-dev is an alias of ibexa/experience dev-master and thus requires it to be installed too.
    - ezsystems/ezplatform-personalization 2.0.x-dev is an alias of ezsystems/ezplatform-personalization dev-master and thus requires it to be installed too.
    - Root composer.json requires ibexa/experience ^4.0.x-dev -> satisfiable by ibexa/experience[4.0.x-dev (alias of dev-master)].
```