### PR TITLE
Added export of PHP_IMAGE variable

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -4,7 +4,7 @@ set -e
 PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 COMPOSE_FILE=$3
-PHP_IMAGE=${4-ezsystems/php:7.3-v2-node12}
+export PHP_IMAGE=${4-ezsystems/php:7.3-v2-node12}
 
 echo "> Setting up website skeleton"
 PROJECT_BUILD_DIR=${HOME}/build/project


### PR DESCRIPTION
Even after https://github.com/ibexa/ci-scripts/pull/10 the builds are still failing, because the PHP_IMAGE is not set everywhere and the default value from .env is used:
https://github.com/ibexa/recipes/blob/master/ibexa/docker/0.1.x-dev/manifest.json#L16

Example failure:
https://travis-ci.com/github/ezsystems/BehatBundle/jobs/503056131
```
Pulling app (ezsystems/php:7.3-v2-node12)...

7.3-v2-node12: Pulling from ezsystems/php

Digest: sha256:ad3ac25f79f57a680861024c800bbfe6caf012b1f5a1c0a9a908fdcf80355dda

Status: Downloaded newer image for ezsystems/php:7.3-v2-node12

Pulling web (nginx:stable)...

stable: Pulling from library/nginx

stable: Pulling from library/nginx

Digest: sha256:c1e6c074ac4f7a543d5a55379ba7bb0d331961b9deca1bc5c5902ef0a354a63d

Status: Downloaded newer image for nginx:stable

Creating ibexa_selenium_1 ... 

Creating ibexa_db_1 ... 

Creating ibexa_db_1

Creating ibexa_selenium_1

Creating ibexa_app_1

Creating ibexa_web_1

Composer detected issues in your platform:

Your Composer dependencies require a PHP version ">= 7.4.0". You are running 7.3.27.

PHP Fatal error:  Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.4.0". You are running 7.3.27. in /var/www/vendor/composer/platform_check.php on line 24
```

It's because the PHP_IMAGE variable is not exported and it's not overrding the default value from `.env` file.

Proof that this approach works:
https://github.com/ezsystems/BehatBundle/pull/181
(green build in https://travis-ci.com/github/ezsystems/BehatBundle/builds/224945286 )