### PR TITLE
Optimized adding dependencies

### DIFF
--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -83,6 +83,7 @@ class LinkDependenciesCommand extends Command
 
         $pullRequestData = new ComposerPullRequestData();
         $pullRequestData->repositoryUrl = $pullRequestDetails['head']['repo']['html_url'];
+        $pullRequestData->privateRepository = $pullRequestDetails['head']['repo']['private'];
         $branchName = $pullRequestDetails['head']['ref'];
         $targetBranch = $pullRequestDetails['base']['ref'];
 

--- a/src/ValueObject/ComposerPullRequestData.php
+++ b/src/ValueObject/ComposerPullRequestData.php
@@ -18,4 +18,7 @@ class ComposerPullRequestData
 
     /** @var string */
     public $package;
+
+    /** @var bool */
+    public $privateRepository;
 }


### PR DESCRIPTION
When looking at https://github.com/ezsystems/ezplatform-page-builder/pull/757 (a build with 20 dependencies) some issues became visible:
1) Composer is making a lot of GitHub API calls, which can even go over the API limit
2) It takes a lot of time to download 20 dependencies.

This PR:
1) Introduces a new property in the dependencies.json schema: `privateRepository`.
Example:
```
    {
        "requirement": "dev-IBX-268-as-editor-i-want-to-see-redesigned-buttons as 2.0.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezcommerce-transaction",
        "package": "ezsystems/ezcommerce-transaction",
        "privateRepository": true
    },
    {
        "requirement": "dev-IBX-268-as-editor-i-want-to-see-redesigned-buttons as 3.0.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-admin-ui",
        "package": "ezsystems/ezplatform-admin-ui",
        "privateRepository": false
    },
```
For public repositories we don't need to add the repository to Composer Repositories, which results in less GitHub API calls:
1) https://github.com/composer/composer/issues/1314#issuecomment-359989539
2) https://github.com/composer/composer/issues/4884#issuecomment-263078612

For private repositories (where VCS is needed) we set the COMPOSER_NO_INTERACTION variable (https://getcomposer.org/doc/03-cli.md#composer-no-interaction) so that Composer fallbacks to git clone if API limits are exceeded:
1) https://github.com/composer/composer/issues/4884#issuecomment-180329041
2) https://github.com/composer/composer/issues/1314#issuecomment-10266196

To speed things up I've also changed how the packages are installed:
instead of multiple composer require calls we add the packages with `--no-install` and then download them in one `composer install` call. 

TO DO:
1) Rebase and retarget this PR to 0.1, it's for master right now so that I can test it with https://github.com/ezsystems/ezplatform-page-builder/pull/757