### PR TITLE
Add VCS repository only for private repos

### DIFF
--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -83,6 +83,7 @@ class LinkDependenciesCommand extends Command
 
         $pullRequestData = new ComposerPullRequestData();
         $pullRequestData->repositoryUrl = $pullRequestDetails['head']['repo']['html_url'];
+        $pullRequestData->privateRepository = $pullRequestDetails['head']['repo']['private'];
         $branchName = $pullRequestDetails['head']['ref'];
         $targetBranch = $pullRequestDetails['base']['ref'];
 

--- a/src/ValueObject/ComposerPullRequestData.php
+++ b/src/ValueObject/ComposerPullRequestData.php
@@ -18,4 +18,7 @@ class ComposerPullRequestData
 
     /** @var string */
     public $package;
+
+    /** @var bool */
+    public $privateRepository;
 }


### PR DESCRIPTION
When looking at ezsystems/ezplatform-page-builder#757 (a build with 20 dependencies) some issues became visible:

    Composer is making a lot of GitHub API calls, which can even go over the API limit
    It takes a lot of time to download 20 dependencies.

This PR:

    Introduces a new property in the dependencies.json schema: privateRepository.
    Example:

    {
        "requirement": "dev-IBX-268-as-editor-i-want-to-see-redesigned-buttons as 2.0.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezcommerce-transaction",
        "package": "ezsystems/ezcommerce-transaction",
        "privateRepository": true
    },
    {
        "requirement": "dev-IBX-268-as-editor-i-want-to-see-redesigned-buttons as 3.0.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-admin-ui",
        "package": "ezsystems/ezplatform-admin-ui",
        "privateRepository": false
    },

For public repositories we don't need to add the repository to Composer Repositories, which results in less GitHub API calls:

    composer/composer#1314 (comment)
    composer/composer#4884 (comment)

For private repositories (where VCS is needed) we set the COMPOSER_NO_INTERACTION variable (https://getcomposer.org/doc/03-cli.md#composer-no-interaction) so that Composer fallbacks to git clone if API limits are exceeded:

    composer/composer#4884 (comment)
    composer/composer#1314 (comment)

To speed things up I've also changed how the packages are installed:
instead of multiple composer require calls we add the packages with --no-install and then download them in one composer install call.