### PR TITLE
Changed setup to install development version of ibexa/docker

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -83,8 +83,10 @@ git init; git add . > /dev/null;
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force
 
 # Install Docker stack
+docker exec install_dependencies composer config prefer-stable false
 docker exec install_dependencies composer require --dev ibexa/docker:^0.1@dev --no-scripts
 docker exec install_dependencies composer sync-recipes ibexa/docker
+docker exec install_dependencies composer config prefer-stable true
 
 # Add other dependencies if required
 if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then


### PR DESCRIPTION
As you can see in https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/509678933#L1114 :
the stable version of ibexa/docker is used:
```
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/docker (v0.1.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing ibexa/docker (v0.1.0): Extracting archive
```

Even though we specify `ibexa/docker:^0.1@dev`. To install the dev version we need to temporarily disable `prefer-stable` setting.

Required by https://github.com/ibexa/recipes/pull/30