### PR TITLE
Use branch aliases for testing packages & downgrade PHPUnit

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -70,7 +70,9 @@ composer config repositories.localDependency "$JSON_STRING"
 docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W
 
-docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev --no-scripts
+# TMP - install phpunit ^8.0 first
+docker exec install_dependencies composer require --dev phpunit/phpunit:^8.0 -W --no-scripts
+docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev -W --no-scripts
 docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
 
 # Init a repository to avoid Composer asking questions

--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -70,11 +70,8 @@ composer config repositories.localDependency "$JSON_STRING"
 docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W
 
-# Install packages required for testing - disabled prefer-stable so that @dev can be used
-docker exec install_dependencies composer config prefer-stable false
-docker exec install_dependencies composer require --dev ezsystems/behatbundle:*@dev --no-scripts
+docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev --no-scripts
 docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
-docker exec install_dependencies composer config prefer-stable true
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;
@@ -83,10 +80,8 @@ git init; git add . > /dev/null;
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force
 
 # Install Docker stack
-docker exec install_dependencies composer config prefer-stable false
-docker exec install_dependencies composer require --dev ibexa/docker:^0.1@dev --no-scripts
+docker exec install_dependencies composer require --dev ibexa/docker:^0.1.x-dev --no-scripts
 docker exec install_dependencies composer sync-recipes ibexa/docker
-docker exec install_dependencies composer config prefer-stable true
 
 # Add other dependencies if required
 if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then


### PR DESCRIPTION
Travis fails to install the correct version of BehatBundle, it installs 8.0.0-beta4:
```
./composer.json has been updated
Running composer update ezsystems/behatbundle
Loading composer repositories with package information
Updating dependencies
Lock file operations: 10 installs, 0 updates, 0 removals
  - Locking behat/behat (dev-master 689f1e4)
  - Locking behat/gherkin (v4.8.0)
  - Locking behat/mink-selenium2-driver (dev-master 4a4d1af)
  - Locking behat/transliterator (v1.3.0)
  - Locking ezsystems/behatbundle (v8.0.0-beta4)
  - Locking friends-of-behat/mink (v1.9.0)
  - Locking friends-of-behat/mink-extension (v2.5.0)
  - Locking friends-of-behat/symfony-extension (dev-master 7d02274)
  - Locking fzaninotto/faker (dev-master 5ffe7db)
  - Locking instaclick/php-webdriver (1.x-dev b5f330e)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 10 installs, 0 updates, 0 removals
  - Downloading ezsystems/behatbundle (v8.0.0-beta4)
```
The correct version cannot be installed because it conflicts on phpunit:
```
MacBook-Pro:v3 mareknocon$ composer require --dev ezsystems/behatbundle:^8.3.x-dev --no-scripts
./composer.json has been updated
Running composer update ezsystems/behatbundle
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires ezsystems/behatbundle ^8.3.x-dev -> satisfiable by ezsystems/behatbundle[8.3.x-dev].
    - ezsystems/behatbundle 8.3.x-dev requires phpunit/phpunit ^8.5 -> found phpunit/phpunit[8.5.0, ..., 8.5.x-dev] but it conflicts with your root composer.json require (^9.5).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```
Things done:
1) Prefer-stable manipulation can be removed when packages are required using branch-alias as version
2) We downgrade PHPUnit to ^8.0 - thel upgrade to PHPUnit 9 in BehatBundle will occurr in https://github.com/ezsystems/BehatBundle/pull/167

This solution has been tested in https://github.com/ezsystems/ezplatform-admin-ui/pull/1767