### PR TITLE
Marked forks as repositories added as VCS

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -95,9 +95,9 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
         REPO_URL=$(cat dependencies.json | jq -r .[$i].repositoryUrl)
         PACKAGE_NAME=$(cat dependencies.json | jq -r .[$i].package)
         REQUIREMENT=$(cat dependencies.json | jq -r .[$i].requirement)
-        IS_PRIVATE=$(cat dependencies.json | jq -r .[$i].privateRepository)
-        if [[ $IS_PRIVATE == "true" ]] ; then 
-            echo ">> Private repository detected, adding VCS to Composer repositories"
+        SHOULD_BE_ADDED_AS_VCS=$(cat dependencies.json | jq -r .[$i].shouldBeAddedAsVCS)
+        if [[ $SHOULD_BE_ADDED_AS_VCS == "true" ]] ; then 
+            echo ">> Private or fork repository detected, adding VCS to Composer repositories"
             docker exec install_dependencies composer config repositories.$(uuidgen) vcs "$REPO_URL"
         fi
         docker exec install_dependencies composer require ${PACKAGE_NAME}:"$REQUIREMENT" --no-scripts --no-install || true

--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -83,7 +83,7 @@ class LinkDependenciesCommand extends Command
 
         $pullRequestData = new ComposerPullRequestData();
         $pullRequestData->repositoryUrl = $pullRequestDetails['head']['repo']['html_url'];
-        $pullRequestData->privateRepository = $pullRequestDetails['head']['repo']['private'];
+        $pullRequestData->shouldBeAddedAsVCS = $pullRequestDetails['head']['repo']['private'] || $pullRequestDetails['head']['repo']['fork'];
         $branchName = $pullRequestDetails['head']['ref'];
         $targetBranch = $pullRequestDetails['base']['ref'];
 

--- a/src/ValueObject/ComposerPullRequestData.php
+++ b/src/ValueObject/ComposerPullRequestData.php
@@ -20,5 +20,5 @@ class ComposerPullRequestData
     public $package;
 
     /** @var bool */
-    public $privateRepository;
+    public $shouldBeAddedAsVCS;
 }


### PR DESCRIPTION
Follow up to https://github.com/ibexa/ci-scripts/pull/13/
Forks should also be added as VCS repositories, otherwise Composer is unable to find requested branch.

Proof that it works when generating (adds VCS for private or forks repositories, does not add for public repositories).
```
MacBook-Pro:ci-scripts mareknocon$ bin/travis dependencies:link

 Please enter the number of related Pull Requests [1]:
 > 3

 Link to GitHub PR:
 > https://github.com/ezsystems/ezplatform-admin-ui/pull/1789

 Link to GitHub PR:
 > https://github.com/ezsystems/ezplatform-page-builder/pull/775

 Link to GitHub PR:
 > https://github.com/ezsystems/ezplatform-kernel/pull/208



 [OK] Successfully generated dependencies.json file


MacBook-Pro:ci-scripts mareknocon$ cat dependencies.json
[
    {
        "requirement": "dev-ibx-579-add-location-40 as 3.0.x-dev",
        "repositoryUrl": "https://github.com/micszo/ezplatform-admin-ui",
        "package": "ezsystems/ezplatform-admin-ui",
        "shouldBeAddedAsVCS": true
    },
    {
        "requirement": "dev-ibx-676-fixed-switcher-icons as 1.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-page-builder",
        "package": "ezsystems/ezplatform-page-builder",
        "shouldBeAddedAsVCS": true
    },
    {
        "requirement": "dev-ibx_688 as 1.3.x-dev",
        "repositoryUrl": "https://github.com/ezsystems/ezplatform-kernel",
        "package": "ezsystems/ezplatform-kernel",
        "shouldBeAddedAsVCS": false
    }
]
```

### TODO:
~~1) Make sure it works on Travis~~

Tested on Travis:
https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/530646412#L1180

You can see that a fork dependency has been added correctly: https://github.com/ezsystems/ezplatform-admin-ui/pull/1846