### PR TITLE
Disabled execution of scripts for installation process

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -68,11 +68,11 @@ composer config repositories.localDependency "$JSON_STRING"
 
 # Install correct product variant
 docker exec install_dependencies composer update
-docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W
+docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # TMP - install phpunit ^8.0 first
 docker exec install_dependencies composer require --dev phpunit/phpunit:^8.0 -W --no-scripts
-docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev -W --no-scripts
+docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev -W --no-scripts --no-plugins
 docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
 
 # Init a repository to avoid Composer asking questions


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-943

This PR implements the fix from https://issues.ibexa.co/browse/IBX-943?focusedCommentId=260335&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-260335 for Travis

`--no-plugins` is needed to disable Symfony Flex when BehatBundle is installed - in previous Composer versions `--no-scripts` was enough to achieve that.