### PR TITLE
Added SSH fallback and corrected commit message

### DIFF
--- a/src/Command/LinkDependenciesCommand.php
+++ b/src/Command/LinkDependenciesCommand.php
@@ -70,7 +70,7 @@ class LinkDependenciesCommand extends Command
         preg_match('/.*github.com\/(.*)\/(.*)\/pull\/(\d+).*/', $pullRequestURL, $matches);
         [, $owner, $repository, $prNumber] = $matches;
 
-        if ($repository === "recipes") {
+        if ($repository === 'recipes') {
             throw new \RuntimeException('Symfony Flex recipes are not supported as dependencies. Please consult QA team what can be done in this case.');
         }
 

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -24,7 +24,7 @@ class RunRegressionCommand extends Command
 
     private const REPO_NAME = 'ezplatform-page-builder';
 
-    private const COMMIT_MESSAGE = '[TMP] Run Regression';
+    private const COMMIT_MESSAGE = '[TMP] Run regression';
 
     /** @var ?string */
     private $token;


### PR DESCRIPTION
This PR:
1) adds a fallback cloning method (using SSH), because not everyone has Git configured to use HTTPS
2) corrects the commit message used to run regression (ref: https://github.com/ezsystems/ezplatform-page-builder/blob/master/.travis.yml#L33)