### PR TITLE
Added workaround for newer Docker Compose versions

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -114,6 +114,12 @@ fi
 docker container stop install_dependencies
 docker container rm install_dependencies
 
+# TODO: Remove when Travis is no longer used
+# Workaround for older docker-compose versions
+# Newer docker-compose versions look for the .env file in doc/docker
+# Older use the current working directory (and do not support the --env-file option)
+sudo cp .env doc/docker
+
 echo "> Start docker containers specified by ${COMPOSE_FILE}"
 docker-compose up -d
 


### PR DESCRIPTION
Example failing build:

https://app.travis-ci.com/github/ezsystems/ezplatform-http-cache/builds/242157318

Looks like Travis updated the Docker & Docker Compose version for `xenial` dist:

- last passing build : https://app.travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/548784047
```
docker version
Server:
 Engine:
  Version:          18.06.0-ce
```
- first failing build: https://app.travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/548950175
```
docker version
Server: Docker Engine - Community
 Engine:
  Version:          20.10.7
```

Nothing changed for Trusty - the older version is still used there and the builds keep passing:
https://app.travis-ci.com/github/ezsystems/ezplatform/builds/242157222

This will fix the build for v3.3, can be reverted on master - I will make a separate PR for 2.5

Proof that it works is in https://github.com/ezsystems/ezplatform-http-cache/pull/161