### PR TITLE
Removed installing BehatBundle with all dependencies

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -71,7 +71,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install BehatBundle
-docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev -W --no-scripts --no-plugins
+docker exec install_dependencies composer require --dev ezsystems/behatbundle:^8.3.x-dev --no-scripts --no-plugins
 docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
 
 # Init a repository to avoid Composer asking questions


### PR DESCRIPTION
Example failure: https://app.travis-ci.com/github/ezsystems/ezplatform-workflow/jobs/550055643

Installing BehatBundle with the `-W` (`--with-all-dependencies`) option bumps all Symfony packages to 5.4.0:
```
Running composer update ezsystems/behatbundle --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Lock file operations: 24 installs, 24 updates, 0 removals
  - Locking behat/behat (v3.10.0)
  - Locking behat/gherkin (v4.9.0)
  - Locking behat/mink-goutte-driver (v1.3.0)
  - Locking behat/mink-selenium2-driver (v1.5.0)
  - Locking behat/transliterator (v1.3.0)
  - Locking bex/behat-extension-driver-locator (2.0.1)
  - Locking bex/behat-screenshot (2.1.0)
  - Locking cloudinary/cloudinary_php (1.20.0)
  - Locking dmore/behat-chrome-extension (1.3.0)
  - Locking dmore/chrome-mink-driver (2.8.0)
  - Locking ezsystems/allure-behat (v3.1.2)
  - Locking ezsystems/allure-php-api (v3.1.2)
  - Locking ezsystems/behat-screenshot-image-driver-cloudinary (v1.1.4)
  - Locking ezsystems/behatbundle (8.3.x-dev 3fb1cfa)
  - Locking fabpot/goutte (v3.3.1)
  - Locking friends-of-behat/mink (v1.9.0)
  - Locking friends-of-behat/mink-browserkit-driver (v1.5.0)
  - Locking friends-of-behat/mink-extension (v2.5.0)
  - Locking friends-of-behat/symfony-extension (v2.2.1)
  - Locking fzaninotto/faker (v1.9.2)
  - Locking instaclick/php-webdriver (1.4.10)
  - Locking liuggio/fastest (v1.8.0)
  - Locking psy/psysh (v0.10.11)
  - Upgrading symfony/cache (v5.3.12 => v5.4.0)
  - Upgrading symfony/config (v5.3.11 => v5.4.0)
  - Upgrading symfony/dependency-injection (v5.3.11 => v5.4.0)
  - Upgrading symfony/doctrine-bridge (v5.3.11 => v5.4.0)
  - Upgrading symfony/dom-crawler (v5.3.7 => v5.4.0)
  - Upgrading symfony/error-handler (v5.3.11 => v5.4.0)
  - Upgrading symfony/event-dispatcher (v5.3.11 => v5.4.0)
  - Upgrading symfony/filesystem (v5.3.4 => v5.4.0)
  - Upgrading symfony/finder (v5.3.7 => v5.4.0)
  - Upgrading symfony/http-foundation (v5.3.11 => v5.4.0)
  - Upgrading symfony/lock (v5.3.10 => v5.4.0)
  - Upgrading symfony/monolog-bridge (v5.3.7 => v5.4.0)
  - Upgrading symfony/options-resolver (v5.3.7 => v5.4.0)
  - Upgrading symfony/password-hasher (v5.3.8 => v5.4.0)
  - Upgrading symfony/routing (v5.3.11 => v5.4.0)
  - Upgrading symfony/security-core (v5.3.11 => v5.4.0)
  - Upgrading symfony/security-csrf (v5.3.4 => v5.4.0)
  - Upgrading symfony/security-guard (v5.3.7 => v5.4.0)
  - Upgrading symfony/security-http (v5.3.11 => v5.4.0)
  - Upgrading symfony/templating (v5.3.7 => v5.4.0)
  - Upgrading symfony/twig-bridge (v5.3.11 => v5.4.0)
  - Upgrading symfony/var-dumper (v5.3.11 => v5.4.0)
  - Upgrading symfony/var-exporter (v5.3.11 => v5.4.0)
  - Upgrading symfony/workflow (v5.3.4 => v5.4.0)
  - Locking textalk/websocket (1.5.5)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 24 installs, 24 updates, 0 removals
  - Downloading symfony/routing (v5.4.0)
  - Downloading symfony/http-foundation (v5.4.0)
  - Downloading symfony/event-dispatcher (v5.4.0)
  - Downloading symfony/var-dumper (v5.4.0)
  - Downloading symfony/error-handler (v5.4.0)
  - Downloading symfony/dependency-injection (v5.4.0)
  - Downloading symfony/filesystem (v5.4.0)
  - Downloading symfony/config (v5.4.0)
  - Downloading symfony/password-hasher (v5.4.0)
  - Downloading symfony/security-core (v5.4.0)
  - Downloading symfony/security-http (v5.4.0)
  - Downloading symfony/security-guard (v5.4.0)
  - Downloading symfony/security-csrf (v5.4.0)
  - Downloading symfony/finder (v5.4.0)
  - Downloading symfony/var-exporter (v5.4.0)
  - Downloading symfony/cache (v5.4.0)
  - Downloading symfony/options-resolver (v5.4.0)
  - Downloading symfony/dom-crawler (v5.4.0)
  - Downloading symfony/twig-bridge (v5.4.0)
  - Downloading symfony/templating (v5.4.0)
  - Downloading symfony/doctrine-bridge (v5.4.0)
  - Downloading symfony/lock (v5.4.0)
  - Downloading ezsystems/behatbundle (8.3.x-dev 3fb1cfa)
  - Downloading symfony/monolog-bridge (v5.4.0)
  - Downloading symfony/workflow (v5.4.0)
  - Upgrading symfony/routing (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/http-foundation (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/event-dispatcher (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/var-dumper (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/error-handler (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/dependency-injection (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/filesystem (v5.3.4 => v5.4.0): Extracting archive
  - Upgrading symfony/config (v5.3.11 => v5.4.0): Extracting archive
  - Installing behat/gherkin (v4.9.0): Extracting archive
  - Installing behat/transliterator (v1.3.0): Extracting archive
  - Installing behat/behat (v3.10.0): Extracting archive
  - Installing bex/behat-extension-driver-locator (2.0.1): Extracting archive
  - Installing cloudinary/cloudinary_php (1.20.0): Extracting archive
  - Upgrading symfony/password-hasher (v5.3.8 => v5.4.0): Extracting archive
  - Upgrading symfony/security-core (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/security-http (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/security-guard (v5.3.7 => v5.4.0): Extracting archive
  - Upgrading symfony/security-csrf (v5.3.4 => v5.4.0): Extracting archive
  - Upgrading symfony/finder (v5.3.7 => v5.4.0): Extracting archive
  - Upgrading symfony/var-exporter (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/cache (v5.3.12 => v5.4.0): Extracting archive
  - Upgrading symfony/options-resolver (v5.3.7 => v5.4.0): Extracting archive
  - Installing psy/psysh (v0.10.11): Extracting archive
  - Installing liuggio/fastest (v1.8.0): Extracting archive
  - Installing fzaninotto/faker (v1.9.2): Extracting archive
  - Installing friends-of-behat/symfony-extension (v2.2.1): Extracting archive
  - Installing friends-of-behat/mink (v1.9.0): Extracting archive
  - Installing friends-of-behat/mink-extension (v2.5.0): Extracting archive
  - Upgrading symfony/dom-crawler (v5.3.7 => v5.4.0): Extracting archive
  - Installing friends-of-behat/mink-browserkit-driver (v1.5.0): Extracting archive
  - Upgrading symfony/twig-bridge (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/templating (v5.3.7 => v5.4.0): Extracting archive
  - Upgrading symfony/doctrine-bridge (v5.3.11 => v5.4.0): Extracting archive
  - Upgrading symfony/lock (v5.3.10 => v5.4.0): Extracting archive
  - Installing ezsystems/behat-screenshot-image-driver-cloudinary (v1.1.4): Extracting archive
  - Installing ezsystems/allure-php-api (v3.1.2): Extracting archive
  - Installing ezsystems/allure-behat (v3.1.2): Extracting archive
  - Installing textalk/websocket (1.5.5): Extracting archive
  - Installing dmore/chrome-mink-driver (2.8.0): Extracting archive
  - Installing dmore/behat-chrome-extension (1.3.0): Extracting archive
  - Installing bex/behat-screenshot (2.1.0): Extracting archive
  - Installing instaclick/php-webdriver (1.4.10): Extracting archive
  - Installing behat/mink-selenium2-driver (v1.5.0): Extracting archive
  - Installing fabpot/goutte (v3.3.1): Extracting archive
  - Installing behat/mink-goutte-driver (v1.3.0): Extracting archive
  - Installing ezsystems/behatbundle (8.3.x-dev 3fb1cfa): Extracting archive
  - Upgrading symfony/monolog-bridge (v5.3.7 => v5.4.0): Extracting archive
  - Upgrading symfony/workflow (v5.3.4 => v5.4.0): Extracting archive
```

The usage of `-W` is a leftover from https://github.com/ibexa/ci-scripts/pull/15 and can be removed - I've tested it in https://github.com/ibexa/experience/pull/14 and it installs correct BehatBundle version.
```
 Running composer update ezsystems/behatbundle
Loading composer repositories with package information
Updating dependencies
Lock file operations: 24 installs, 0 updates, 0 removals
  - Locking behat/behat (v3.10.0)
  - Locking behat/gherkin (v4.9.0)
  - Locking behat/mink-goutte-driver (v1.3.0)
  - Locking behat/mink-selenium2-driver (v1.5.0)
  - Locking behat/transliterator (v1.3.0)
  - Locking bex/behat-extension-driver-locator (2.0.1)
  - Locking bex/behat-screenshot (2.1.0)
  - Locking cloudinary/cloudinary_php (1.20.0)
  - Locking dmore/behat-chrome-extension (1.3.0)
  - Locking dmore/chrome-mink-driver (2.8.0)
  - Locking ezsystems/allure-behat (v3.1.2)
  - Locking ezsystems/allure-php-api (v3.1.2)
  - Locking ezsystems/behat-screenshot-image-driver-cloudinary (v1.1.4)
  - Locking ezsystems/behatbundle (8.3.x-dev 3fb1cfa)
  - Locking fabpot/goutte (v3.3.1)
  - Locking friends-of-behat/mink (v1.9.0)
  - Locking friends-of-behat/mink-browserkit-driver (v1.5.0)
  - Locking friends-of-behat/mink-extension (v2.5.0)
  - Locking friends-of-behat/symfony-extension (v2.2.1)
  - Locking fzaninotto/faker (v1.9.2)
  - Locking instaclick/php-webdriver (1.4.10)
  - Locking liuggio/fastest (v1.8.0)
  - Locking psy/psysh (v0.10.11)
  - Locking textalk/websocket (1.5.5)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 24 installs, 0 updates, 0 removals
  - Downloading behat/gherkin (v4.9.0)
  - Downloading behat/transliterator (v1.3.0)
  - Downloading behat/behat (v3.10.0)
  - Downloading bex/behat-extension-driver-locator (2.0.1)
  - Downloading cloudinary/cloudinary_php (1.20.0)
  - Downloading psy/psysh (v0.10.11)
  - Downloading liuggio/fastest (v1.8.0)
  - Downloading fzaninotto/faker (v1.9.2)
  - Downloading friends-of-behat/symfony-extension (v2.2.1)
  - Downloading friends-of-behat/mink (v1.9.0)
  - Downloading friends-of-behat/mink-extension (v2.5.0)
  - Downloading friends-of-behat/mink-browserkit-driver (v1.5.0)
  - Downloading ezsystems/behat-screenshot-image-driver-cloudinary (v1.1.4)
  - Downloading ezsystems/allure-php-api (v3.1.2)
  - Downloading ezsystems/allure-behat (v3.1.2)
  - Downloading textalk/websocket (1.5.5)
  - Downloading dmore/chrome-mink-driver (2.8.0)
  - Downloading dmore/behat-chrome-extension (1.3.0)
  - Downloading bex/behat-screenshot (2.1.0)
  - Downloading instaclick/php-webdriver (1.4.10)
  - Downloading behat/mink-selenium2-driver (v1.5.0)
  - Downloading fabpot/goutte (v3.3.1)
  - Downloading behat/mink-goutte-driver (v1.3.0)
  - Downloading ezsystems/behatbundle (8.3.x-dev 3fb1cfa)
```

The Symfony version should be controlled by ibexa/website-skeleton - https://github.com/ibexa/website-skeleton/blob/main/composer.json#L86

And we will have to bump it there to upgrade Symfony.