### PR TITLE
Bumped ibexa/docker version to 0.2

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -81,7 +81,7 @@ git init; git add . > /dev/null;
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force
 
 # Install Docker stack
-docker exec install_dependencies composer require --dev ibexa/docker:^0.1.x-dev --no-scripts
+docker exec install_dependencies composer require --dev ibexa/docker:^0.2.x-dev --no-scripts
 docker exec install_dependencies composer sync-recipes ibexa/docker
 
 # Add other dependencies if required


### PR DESCRIPTION
Requires https://github.com/ibexa/docker/pull/5

We will use the 0.2 version of our Docker stack for v4 (the one that has been adjusted to the `ibexa` org).