### PR TITLE
Limit composer parallelism

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -15,11 +15,14 @@ if [[ -n "${DOCKER_PASSWORD}" ]]; then
     echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 fi
 
+export COMPOSER_MAX_PARALLEL_HTTP=6
+
 # Create container to install dependencies
 docker run --name install_dependencies -d \
 --volume=${PROJECT_BUILD_DIR}:/var/www:cached \
 --volume=${HOME}/.composer:/root/.composer \
 -e APP_ENV -e APP_DEBUG  \
+-e COMPOSER_MAX_PARALLEL_HTTP \
 -e PHP_INI_ENV_memory_limit -e COMPOSER_MEMORY_LIMIT \
 -e COMPOSER_NO_INTERACTION=1 \
 ${PHP_IMAGE}


### PR DESCRIPTION
Example failure: https://github.com/ibexa/admin-ui/runs/4455749036

```
Failed to download recipe: curl error 28 while downloading https://flex.ibexa.co/p/ezsystems,behatbundle,i9.0.x-dev,1638885449: Operation timed out after 300005 milliseconds with 0 bytes received
```
300005 is 5 minutes, which is pretty long

This PR tries to reduce the concurency level of Composer by using the `COMPOSER_MAX_PARALLEL_HTTP` variable.

See more:
https://github.com/composer/composer/issues/9671
https://github.com/composer/composer/commit/40095b20dc58772b7b630e1ca41f024fda7eae44

I'm not sure it will help 100%, but I've tried it and it looks promising. (Tested in https://github.com/ibexa/commerce/pull/24 and https://github.com/ibexa/experience/pull/16)

12 is the default value, so far I've reduced it in half - if it doesn't help we can try the values 3 and 1 next.
