### PR TITLE
Optimized Composer dependency adding

### DIFF
--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -85,7 +85,6 @@ docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITIO
 
 # Install Docker stack
 docker exec install_dependencies composer require --dev ibexa/docker:^0.1.x-dev --no-scripts
-docker exec install_dependencies composer sync-recipes ibexa/docker
 
 # Add other dependencies if required
 if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
@@ -108,10 +107,9 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
 
     docker exec install_dependencies composer update --no-scripts
 
-    for ((i=0;i<$COUNT;i++)); do
-        PACKAGE_NAME=$(cat dependencies.json | jq -r .[$i].package)
-        docker exec install_dependencies composer sync-recipes ${PACKAGE_NAME} --force
-    done
+    # Execute recipes from BehatBundle and docker again, because they use copy-from-package
+    docker exec install_dependencies composer sync-recipes ibexa/docker --force
+    docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
 fi
 
 # Create a default Behat configuration file

--- a/bin/prepare_project_edition.sh
+++ b/bin/prepare_project_edition.sh
@@ -102,10 +102,11 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
             echo ">> Private or fork repository detected, adding VCS to Composer repositories"
             docker exec install_dependencies composer config repositories.$(uuidgen) vcs "$REPO_URL"
         fi
-        docker exec install_dependencies composer require ${PACKAGE_NAME}:"$REQUIREMENT" --no-scripts --no-install || true
+        jq --arg package "$PACKAGE_NAME" --arg requirement "$REQUIREMENT" '.["require"] += { ($package) : ($requirement) }' composer.json > composer.json.new
+        mv composer.json.new composer.json
     done
 
-    docker exec install_dependencies composer install --no-scripts
+    docker exec install_dependencies composer update --no-scripts
 
     for ((i=0;i<$COUNT;i++)); do
         PACKAGE_NAME=$(cat dependencies.json | jq -r .[$i].package)


### PR DESCRIPTION
Things done:
1) Dependencies are not added directly using Composer, instead composer.json is modified using JQ - this speeds things up A LOT
2) We do not need to execute recipes for every package from the dependencies list - ibexa product packages (except the editions) have empty recipes (example: https://github.com/ibexa/recipes/tree/master/ibexa/admin-ui/4.0.x-dev) - executing BehatBundle and docker recipes should be enough, because these are the only ones that use copy-from-package.

Numbers from https://github.com/ibexa/commerce/pull/26: 33 dependencies
Total setup time:
Before: More than 15 minutes (https://github.com/ibexa/commerce/runs/4560313323?check_suite_focus=true)
After: 6 min 11 seconds (https://github.com/ibexa/commerce/runs/4560781582?check_suite_focus=true)

Tested in https://github.com/ibexa/commerce/pull/26

~**I will rebase this PR for 0.1 before merging, it's against main because I've been testing it with v4**~