### PR TITLE
Update only selected packages

### DIFF
--- a/bin/4.1.x-dev/prepare_project_edition.sh
+++ b/bin/4.1.x-dev/prepare_project_edition.sh
@@ -91,6 +91,7 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
     echo "> Adding additional dependencies:"
     cat dependencies.json
     COUNT=$(cat dependencies.json | jq length)
+    PACKAGES_TO_UPDATE=""
     for ((i=0;i<$COUNT;i++)); do
         REPO_URL=$(cat dependencies.json | jq -r .[$i].repositoryUrl)
         PACKAGE_NAME=$(cat dependencies.json | jq -r .[$i].package)
@@ -98,13 +99,19 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
         SHOULD_BE_ADDED_AS_VCS=$(cat dependencies.json | jq -r .[$i].shouldBeAddedAsVCS)
         if [[ $SHOULD_BE_ADDED_AS_VCS == "true" ]] ; then 
             echo ">> Private or fork repository detected, adding VCS to Composer repositories"
-            docker exec install_dependencies composer config repositories.$(uuidgen) vcs "$REPO_URL"
+            JSON_STRING=$( jq -n \
+                  --arg repositoryURL "$REPO_URL" \
+                  --arg packageName "$DEPENDENCY_PACKAGE_NAME" \
+                  --arg packageDir "./$DEPENDENCY_PACKAGE_NAME" \
+                  '{"type": "vcs", "no-api": true, "url": $repositoryURL}' )
+            docker exec install_dependencies composer config repositories.$(uuidgen) "$JSON_STRING"
         fi
         jq --arg package "$PACKAGE_NAME" --arg requirement "$REQUIREMENT" '.["require"] += { ($package) : ($requirement) }' composer.json > composer.json.new
         mv composer.json.new composer.json
+        PACKAGES_TO_UPDATE="$PACKAGES_TO_UPDATE $PACKAGE_NAME"
     done
 
-    docker exec install_dependencies composer update --no-scripts
+    docker exec install_dependencies composer update $PACKAGES_TO_UPDATE --no-scripts --no-plugins
 
     # Execute recipes from behat and docker again, because they use copy-from-package
     docker exec install_dependencies composer sync-recipes ibexa/docker --force --reset

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -91,6 +91,7 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
     echo "> Adding additional dependencies:"
     cat dependencies.json
     COUNT=$(cat dependencies.json | jq length)
+    PACKAGES_TO_UPDATE=""
     for ((i=0;i<$COUNT;i++)); do
         REPO_URL=$(cat dependencies.json | jq -r .[$i].repositoryUrl)
         PACKAGE_NAME=$(cat dependencies.json | jq -r .[$i].package)
@@ -98,13 +99,19 @@ if [ -f ./${DEPENDENCY_PACKAGE_NAME}/dependencies.json ]; then
         SHOULD_BE_ADDED_AS_VCS=$(cat dependencies.json | jq -r .[$i].shouldBeAddedAsVCS)
         if [[ $SHOULD_BE_ADDED_AS_VCS == "true" ]] ; then 
             echo ">> Private or fork repository detected, adding VCS to Composer repositories"
-            docker exec install_dependencies composer config repositories.$(uuidgen) vcs "$REPO_URL"
+            JSON_STRING=$( jq -n \
+                  --arg repositoryURL "$REPO_URL" \
+                  --arg packageName "$DEPENDENCY_PACKAGE_NAME" \
+                  --arg packageDir "./$DEPENDENCY_PACKAGE_NAME" \
+                  '{"type": "vcs", "no-api": true, "url": $repositoryURL}' )
+            docker exec install_dependencies composer config repositories.$(uuidgen) "$JSON_STRING"
         fi
         jq --arg package "$PACKAGE_NAME" --arg requirement "$REQUIREMENT" '.["require"] += { ($package) : ($requirement) }' composer.json > composer.json.new
         mv composer.json.new composer.json
+        PACKAGES_TO_UPDATE="$PACKAGES_TO_UPDATE $PACKAGE_NAME"
     done
 
-    docker exec install_dependencies composer update --no-scripts
+    docker exec install_dependencies composer update $PACKAGES_TO_UPDATE --no-scripts --no-plugins
 
     # Execute recipes from BehatBundle and docker again, because they use copy-from-package
     docker exec install_dependencies composer sync-recipes ibexa/docker --force --reset


### PR DESCRIPTION
I've encountered some issues when trying to run tests on Travis and Github Actions using a dependency.

Example error:
```
Loading composer repositories with package information
  [Composer\Downloader\TransportException]   
  Could not authenticate against github.com                      
update [--with WITH] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-dev] [--lock] [--no-install] [--no-autoloader] [--no-suggest] [--no-progress] [-w|--with-dependencies] [-W|--with-all-dependencies] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-i|--interactive] [--root-reqs] [--] [<packages>]...
```

https://app.travis-ci.com/github/ezsystems/ezplatform-http-cache/jobs/555454678

This PR changes three things:
1) Only the packages that were specified in dependencies.json are updated (we don't run full `composer update`, but `composer update <package1> <package2>` etc.
2) Plugins are disabled (no need to check Flex recipes) - the only recipes that can change are run always (behatbundle and ibexa/docker)
3) Added the `no-api` flag to repositories that are private/from forks. This should limit the number of API requests that Composer is making. See: https://getcomposer.org/doc/05-repositories.md#git-alternatives

Tested in:
- https://github.com/ezsystems/ezplatform-http-cache/pull/166
- https://github.com/ibexa/oss/pull/47
- https://github.com/ibexa/commerce/pull/56