### PR TITLE
Recipes issue workaround

### DIFF
--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -115,6 +115,9 @@ fi
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
+# TMP Workaround for assets issue
+sudo sed -i "s/'%kernel.project_dir%\/public\/build\/manifest.json'/~/g" config/packages/webpack_encore.yaml
+
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies
@@ -134,6 +137,7 @@ docker-compose exec -T app sh -c 'chown -R www-data:www-data /var/www'
 
 # Rebuild container
 docker-compose exec -T --user www-data app sh -c "rm -rf var/cache/*"
+
 echo '> Clear cache & generate assets'
 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -134,15 +134,13 @@ docker-compose exec -T app sh -c 'chown -R www-data:www-data /var/www'
 
 # Rebuild container
 docker-compose exec -T --user www-data app sh -c "rm -rf var/cache/*"
-docker-compose exec -T --user www-data app php bin/console cache:clear
+echo '> Clear cache & generate assets'
+docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 
 echo '> Install data'
 docker-compose exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 
 echo '> Generate GraphQL schema'
 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"
-
-echo '> Clear cache & generate assets'
-docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 
 echo '> Done, ready to run tests'

--- a/bin/^4.0.x-dev/prepare_project_edition.sh
+++ b/bin/^4.0.x-dev/prepare_project_edition.sh
@@ -115,6 +115,9 @@ fi
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
+# TMP Workaround for assets issue
+sudo sed -i "s/'%kernel.project_dir%\/public\/build\/manifest.json'/~/g" config/packages/webpack_encore.yaml
+
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies
@@ -128,6 +131,7 @@ docker-compose --env-file=.env exec -T app sh -c 'chown -R www-data:www-data /va
 
 # Rebuild container
 docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cache/*"
+
 echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 

--- a/bin/^4.0.x-dev/prepare_project_edition.sh
+++ b/bin/^4.0.x-dev/prepare_project_edition.sh
@@ -128,7 +128,8 @@ docker-compose --env-file=.env exec -T app sh -c 'chown -R www-data:www-data /va
 
 # Rebuild container
 docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cache/*"
-docker-compose --env-file=.env exec -T --user www-data app php bin/console cache:clear
+echo '> Clear cache & generate assets'
+docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
 echo '> Install data'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
@@ -136,7 +137,6 @@ docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/w
 echo '> Generate GraphQL schema'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"
 
-echo '> Clear cache & generate assets'
-docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+
 
 echo '> Done, ready to run tests'


### PR DESCRIPTION
I've done two things here:
1) `composer run post-install-cmd` is run after the recipes are executed

Previously only the cache has been cleared, but it's not compliant with our manual Flex installation doc

2) The changes from https://github.com/symfony/recipes/commit/ea6ade9061ceef1acf8ccb9e53f34b1c3aa9c966#diff-2536b2d64808a2dc850401fd3bcdb5d97319ebe7a67e6fc18ef1eddd163b5d0eR37-R39 are overwritten - the value is set to null (https://github.com/ibexa/recipes/blob/master/ibexa/oss/4.0.x-dev/config/packages/ibexa_assets.yaml#L8)

After the issue is fixed we will need to revert the second commit

Tested in https://github.com/ezsystems/BehatBundle/pull/260, the tests have started correctly