### PR TITLE
Revert "[Workaround] Set framework.assets.json_manifest_path to null"

### DIFF
--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -115,9 +115,6 @@ fi
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
-# TMP Workaround for assets issue
-sudo sed -i "s/'%kernel.project_dir%\/public\/build\/manifest.json'/~/g" config/packages/webpack_encore.yaml
-
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies
@@ -137,7 +134,6 @@ docker-compose exec -T app sh -c 'chown -R www-data:www-data /var/www'
 
 # Rebuild container
 docker-compose exec -T --user www-data app sh -c "rm -rf var/cache/*"
-
 echo '> Clear cache & generate assets'
 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 

--- a/bin/^4.0.x-dev/prepare_project_edition.sh
+++ b/bin/^4.0.x-dev/prepare_project_edition.sh
@@ -115,9 +115,6 @@ fi
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
-# TMP Workaround for assets issue
-sudo sed -i "s/'%kernel.project_dir%\/public\/build\/manifest.json'/~/g" config/packages/webpack_encore.yaml
-
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies
@@ -131,7 +128,6 @@ docker-compose --env-file=.env exec -T app sh -c 'chown -R www-data:www-data /va
 
 # Rebuild container
 docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cache/*"
-
 echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 


### PR DESCRIPTION
This reverts commit e807edbbccb993052f407f5e9eb0e752ae64b1f6 from https://github.com/ibexa/ci-scripts/pull/37

The relevant fixes have been already merged, see: https://issues.ibexa.co/browse/IBX-2299