### PR TITLE
Changed install procedure to execute friendsofbehat/symfony-extension recipe when installing BehatBundle

### DIFF
--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -74,8 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install BehatBundle
-docker exec install_dependencies composer require ezsystems/behatbundle:^8.3.x-dev --no-scripts --no-plugins
-docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
+docker exec install_dependencies composer require ezsystems/behatbundle:^8.3.x-dev --no-scripts
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;

--- a/bin/^4.0.x-dev/prepare_project_edition.sh
+++ b/bin/^4.0.x-dev/prepare_project_edition.sh
@@ -74,8 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install BehatBundle
-docker exec install_dependencies composer require ezsystems/behatbundle:^9.0.x-dev --no-scripts --no-plugins
-docker exec install_dependencies composer sync-recipes ezsystems/behatbundle --force
+docker exec install_dependencies composer require ezsystems/behatbundle:^9.0.x-dev --no-scripts
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;


### PR DESCRIPTION
The friends-of-behat/symfony-extension is enabled by default only in the `test` env:
https://github.com/symfony/recipes-contrib/blob/master/friends-of-behat/symfony-extension/2.0/manifest.json#L3

We need to enable it in `behat` env as well, which we do in our BehatBundle recipe:
https://github.com/ibexa/recipes/blob/master/ezsystems/behatbundle/8.3.x-dev/manifest.json#L4

Before the latest release of symfony/flex it was not possible to change anything in the config/bundles.php file after it has been added, so we had to avoid executing the `friends-of-behat/symfony-extension` recipe to make sure the value is correct (behat, test).

This has changed, now it's possible to change the value in bundles.php file - so we can simplify this logic and simply execute all the needed recipes.

Currently the tests are failing because the BehatBundle recipes is executed first (setting the value to `behat,test`) and then the friendsofbehat/symfony-extension recipe is executed which sets it back to `test`.

Tested in https://github.com/ezsystems/BehatBundle/pull/262 - you can see that the tests started successfuly