### PR TITLE
Added workaround for JSRoutingBundle mkdir issue

### DIFF
--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -136,6 +136,9 @@ docker-compose exec -T --user www-data app sh -c "rm -rf var/cache/*"
 echo '> Clear cache & generate assets'
 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 
+# Create cache directory for JSRoutingBundle, see https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
+docker-compose --env-file=.env exec -T --user www-data app sh -c "mkdir var/cache/$APP_ENV/fosJsRouting"
+
 echo '> Install data'
 docker-compose exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 

--- a/bin/^4.0.x-dev/prepare_project_edition.sh
+++ b/bin/^4.0.x-dev/prepare_project_edition.sh
@@ -130,6 +130,9 @@ docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cac
 echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
+# Workaround: create cache directory for JSRoutingBundle, see https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
+docker-compose --env-file=.env exec -T --user www-data app sh -c "mkdir var/cache/$APP_ENV/fosJsRouting"
+
 echo '> Install data'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 


### PR DESCRIPTION
Example failure:
```
request.CRITICAL: Uncaught PHP Exception ErrorException: 
"Warning: mkdir(): File exists" at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php line 179 
{"exception":"[object] (ErrorException(code: 0): 
Warning: mkdir(): File exists at /var/www/vendor/friendsofsymfony/jsrouting-bundle/Extractor/ExposedRoutesExtractor.php:179)"} []
```

The issue should be solved in the upstream package (see: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434) but we won't be able to use that - the 3.x version is released only for PHP 8, we are using version 2.8.0 and need to use the workaround until we can upgrade.

Tested in https://github.com/ibexa/experience/pull/26