### PR TITLE
Removed creating the workaround directory for JsRoutingBundle

### DIFF
--- a/bin/4.0.x-dev/prepare_project_edition.sh
+++ b/bin/4.0.x-dev/prepare_project_edition.sh
@@ -130,9 +130,6 @@ docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cac
 echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
-# Workaround: create cache directory for JSRoutingBundle, see https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
-docker-compose --env-file=.env exec -T --user www-data app sh -c "mkdir var/cache/$APP_ENV/fosJsRouting"
-
 echo '> Install data'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 

--- a/bin/4.1.x-dev/prepare_project_edition.sh
+++ b/bin/4.1.x-dev/prepare_project_edition.sh
@@ -130,9 +130,6 @@ docker-compose --env-file=.env exec -T --user www-data app sh -c "rm -rf var/cac
 echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
-# Workaround: create cache directory for JSRoutingBundle, see https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
-docker-compose --env-file=.env exec -T --user www-data app sh -c "mkdir var/cache/$APP_ENV/fosJsRouting"
-
 echo '> Install data'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -136,9 +136,6 @@ docker-compose exec -T --user www-data app sh -c "rm -rf var/cache/*"
 echo '> Clear cache & generate assets'
 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
 
-# Create cache directory for JSRoutingBundle, see https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
-docker-compose --env-file=.env exec -T --user www-data app sh -c "mkdir var/cache/$APP_ENV/fosJsRouting"
-
 echo '> Install data'
 docker-compose exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
 


### PR DESCRIPTION
Replaced by https://github.com/ezsystems/BehatBundle/pull/269 which will create the directory on each `cache:clear` Command execution.

We need to drop this approach, because in the current way the directory disappears every time `cache:clear` is run (the cache directory is recreated and manual modifications are lost).