### PR TITLE
Fixed installed version of ibexa/behat

### DIFF
--- a/bin/4.0.x-dev/prepare_project_edition.sh
+++ b/bin/4.0.x-dev/prepare_project_edition.sh
@@ -74,7 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install ibexa/behat
-docker exec install_dependencies composer require ibexa/behat:^4.0.x-dev --no-scripts
+docker exec install_dependencies composer require ibexa/behat:~4.0.x-dev --no-scripts
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;

--- a/bin/4.1.x-dev/prepare_project_edition.sh
+++ b/bin/4.1.x-dev/prepare_project_edition.sh
@@ -74,7 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install ibexa/behat
-docker exec install_dependencies composer require ibexa/behat:^4.0.x-dev --no-scripts
+docker exec install_dependencies composer require ibexa/behat:~4.1.x-dev --no-scripts
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;


### PR DESCRIPTION
Failing test: https://github.com/ibexa/workflow/actions/runs/2148029030
```
  - Locking ibexa/behat (v4.1.0-rc1)
```
```
      Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Call to undefined method Ibexa\Behat\Browser\Element\Element::scrollToBottom() in vendor/ibexa/workflow/src/lib/Behat/Component/Table/ReviewQueue.php:39
```

1) 4.1 should use the 4.1.x-dev version (currently it uses 4.1.0-rc1)
2) 4.0 should use the 4.0.x-dev version 

Tested in https://github.com/ibexa/workflow/pull/46:
```
  - Downloading ibexa/behat (dev-main 57b06d0)
```