### PR TITLE
Reexecute ibexa/behat recipes

### DIFF
--- a/bin/4.0.x-dev/prepare_project_edition.sh
+++ b/bin/4.0.x-dev/prepare_project_edition.sh
@@ -74,7 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install ibexa/behat
-docker exec install_dependencies composer require ibexa/behat:~4.0.x-dev --no-scripts
+docker exec install_dependencies composer require ibexa/behat:~4.0.x-dev --no-scripts --no-plugins
 docker exec install_dependencies composer recipes:install ibexa/behat --force --reset
 
 # Init a repository to avoid Composer asking questions

--- a/bin/4.0.x-dev/prepare_project_edition.sh
+++ b/bin/4.0.x-dev/prepare_project_edition.sh
@@ -75,6 +75,7 @@ docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT
 
 # Install ibexa/behat
 docker exec install_dependencies composer require ibexa/behat:~4.0.x-dev --no-scripts
+docker exec install_dependencies composer recipes:install ibexa/behat --force --reset
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;

--- a/bin/4.1.x-dev/prepare_project_edition.sh
+++ b/bin/4.1.x-dev/prepare_project_edition.sh
@@ -74,7 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install ibexa/behat
-docker exec install_dependencies composer require ibexa/behat:~4.1.x-dev --no-scripts
+docker exec install_dependencies composer require ibexa/behat:~4.1.x-dev --no-scripts --no-plugins
 docker exec install_dependencies composer recipes:install ibexa/behat --force --reset
 
 # Init a repository to avoid Composer asking questions

--- a/bin/4.1.x-dev/prepare_project_edition.sh
+++ b/bin/4.1.x-dev/prepare_project_edition.sh
@@ -75,6 +75,7 @@ docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT
 
 # Install ibexa/behat
 docker exec install_dependencies composer require ibexa/behat:~4.1.x-dev --no-scripts
+docker exec install_dependencies composer recipes:install ibexa/behat --force --reset
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -75,6 +75,7 @@ docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT
 
 # Install BehatBundle
 docker exec install_dependencies composer require ezsystems/behatbundle:^8.3.x-dev --no-scripts
+docker exec install_dependencies composer recipes:install ezsystems/behatbundle --force --reset
 
 # Init a repository to avoid Composer asking questions
 git init; git add . > /dev/null;

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -74,7 +74,7 @@ docker exec install_dependencies composer update
 docker exec -e APP_ENV=dev install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts
 
 # Install BehatBundle
-docker exec install_dependencies composer require ezsystems/behatbundle:^8.3.x-dev --no-scripts
+docker exec install_dependencies composer require ezsystems/behatbundle:^8.3.x-dev --no-scripts --no-plugins
 docker exec install_dependencies composer recipes:install ezsystems/behatbundle --force --reset
 
 # Init a repository to avoid Composer asking questions


### PR DESCRIPTION
We can't execute the `friendfsofbehat/symfonyextension` recipe (installed as dependency of our Behat package) because it sets the following bundles entry:
```
    FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test' => true],
```

and we need to set it as:
```
    FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test' => true, 'behat' => true],
```

Tested in https://github.com/ezsystems/BehatBundle/pull/273 and https://github.com/ibexa/behat/pull/13