### PR TITLE
Fixed branch selection for excluding packages

### DIFF
--- a/bin/4.2.x-dev/prepare_project_edition.sh
+++ b/bin/4.2.x-dev/prepare_project_edition.sh
@@ -71,6 +71,25 @@ fi
 
 if [[ "$PROJECT_EDITION" != "oss" ]]; then
     composer config repositories.ibexa composer https://updates.ibexa.co
+
+    editions=(commerce experience content)
+
+    IBEXA_PACKAGES="[]"
+    for EDITION in "${editions[@]}"; do
+        if [[ "$PROJECT_EDITION" == "$EDITION" ]]; then
+            break
+        fi
+        BRANCH=${GITHUB_BASE_REF:-"$GITHUB_REF_NAME"} # Fallback to GITHUB_REF_NAME for non-PR builds
+        COMPOSER_JSON_CONTENT=$(curl -s "https://raw.githubusercontent.com/ibexa/$EDITION/$BRANCH/composer.json")
+        EDITION_PACKAGES=$(echo "$COMPOSER_JSON_CONTENT" | \
+            jq -r --arg projectEdition "ibexa/$PROJECT_EDITION" \
+            '.require | with_entries(select(.key | contains("ibexa/"))) | with_entries(select(.key == $projectEdition | not )) | keys')
+        IBEXA_PACKAGES=$(echo "$IBEXA_PACKAGES" | jq --argjson editionPackages "$EDITION_PACKAGES" '. + $editionPackages')
+
+    done
+
+    jq --argjson ibexaPackages "$IBEXA_PACKAGES" '.repositories.ibexa.exclude = $ibexaPackages' composer.json > composer.json.new
+    mv composer.json.new composer.json
 fi
 
 echo "> Make composer use tested dependency"
@@ -111,6 +130,9 @@ docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITIO
 
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
+
+echo "> Display composer.json for debugging"
+cat composer.json
 
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml

--- a/bin/4.2.x-dev/prepare_project_edition.sh
+++ b/bin/4.2.x-dev/prepare_project_edition.sh
@@ -79,8 +79,7 @@ if [[ "$PROJECT_EDITION" != "oss" ]]; then
         if [[ "$PROJECT_EDITION" == "$EDITION" ]]; then
             break
         fi
-        BRANCH=${GITHUB_BASE_REF:-"$GITHUB_REF_NAME"} # Fallback to GITHUB_REF_NAME for non-PR builds
-        COMPOSER_JSON_CONTENT=$(curl -s "https://raw.githubusercontent.com/ibexa/$EDITION/$BRANCH/composer.json")
+        COMPOSER_JSON_CONTENT=$(curl -s "https://raw.githubusercontent.com/ibexa/$EDITION/master/composer.json")
         EDITION_PACKAGES=$(echo "$COMPOSER_JSON_CONTENT" | \
             jq -r --arg projectEdition "ibexa/$PROJECT_EDITION" \
             '.require | with_entries(select(.key | contains("ibexa/"))) | with_entries(select(.key == $projectEdition | not )) | keys')

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -79,8 +79,7 @@ if [[ "$PROJECT_EDITION" != "oss" ]]; then
         if [[ "$PROJECT_EDITION" == "$EDITION" ]]; then
             break
         fi
-        BRANCH=${GITHUB_BASE_REF:-"$GITHUB_REF_NAME"} # Fallback to GITHUB_REF_NAME for non-PR builds
-        COMPOSER_JSON_CONTENT=$(curl -s "https://raw.githubusercontent.com/ibexa/$EDITION/$BRANCH/composer.json")
+        COMPOSER_JSON_CONTENT=$(curl -s "https://raw.githubusercontent.com/ibexa/$EDITION/3.3/composer.json")
         EDITION_PACKAGES=$(echo "$COMPOSER_JSON_CONTENT" | \
             jq -r --arg projectEdition "ibexa/$PROJECT_EDITION" \
             '.require | with_entries(select(.key | contains("ibexa/") or contains("ezsystems/"))) | with_entries(select(.key == $projectEdition | not )) | keys')


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/ci-scripts/pull/55 , only https://github.com/ibexa/ci-scripts/commit/9eb669c5a9445c070b6faaa3705fcfb442eaa032 constains new code (https://github.com/ibexa/ci-scripts/pull/56/commits/0b7f22ce7b85d266ade4179bee62f0b3f40c42f4 has already been reviewed)

The current branch selection logic is flawed:
- when PR is made to a branch called 1.3 then endpoint `https://raw.githubusercontent.com/ibexa/$EDITION/1.3/composer.json` is used - but `https://raw.githubusercontent.com/ibexa/$EDITION/3.3/composer.json` should be used instead.
- when PR is made to a branch called main then endpoint `https://raw.githubusercontent.com/ibexa/$EDITION/main/composer.json` is used - but `https://raw.githubusercontent.com/ibexa/$EDITION/master/composer.json` should be used instead.

It worked in https://github.com/ibexa/content/pull/53 because the PR base branch (3.3) is the same as the endpoint that should be used - but it fails in https://github.com/ezsystems/ezplatform-version-comparison/pull/79 

I thought I could avoid harcoding the branches by doing some magic with Github env variables, but it's not possible - hardcoding it seems like the easiest solution.

Tested in https://github.com/ezsystems/ezplatform-version-comparison/pull/79