### PR TITLE
Added basic tests and fixed upgraded dependency issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+  pull_request: ~
+
+jobs:
+  cs-fix:
+    name: Run code style check
+    runs-on: "ubuntu-20.04"
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: 'pdo_sqlite, gd'
+          tools: cs2pr
+
+      - uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+
+      - name: Run code style check
+        run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
+  tests:
+    name: Tests
+    runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: pdo_sqlite, gd
+          tools: cs2pr
+
+      - uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+          composer-options: "--prefer-dist --no-progress"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run test suite
+        run: composer run-script --timeout=600 test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -2,7 +2,10 @@
 return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
     ->setFinder(
         PhpCsFixer\Finder::create()
-            ->in(__DIR__ . '/src')
+            ->in([
+                __DIR__ . '/src',
+                __DIR__ . '/tests',
+                ])
             ->files()->name('*.php')
     )
 ;

--- a/bin/ci
+++ b/bin/ci
@@ -22,7 +22,7 @@ if (!class_exists('Symfony\Component\Console\Application', true)) {
 
 $application = new Symfony\Component\Console\Application;
 
-$application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\LinkDependenciesCommand());
-$application->add(new Ibexa\Platform\ContiniousIntegrationScripts\Command\RunRegressionCommand());
+$application->add(new Ibexa\ContiniousIntegrationScripts\Command\LinkDependenciesCommand());
+$application->add(new Ibexa\ContiniousIntegrationScripts\Command\RunRegressionCommand());
 
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Ibexa\\Platform\\ContiniousIntegrationScripts\\": "src/"
+            "Ibexa\\ContiniousIntegrationScripts\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ibexa\\Tests\\ContiniousIntegrationScripts\\": "tests/"
         }
     },
     "extra": {
@@ -32,11 +37,15 @@
     ],
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^1.0@dev",
-        "phpstan/phpstan": "~0.12"
+        "phpstan/phpstan": "~0.12",
+        "phpunit/phpunit": "^9.5",
+        "mikey179/vfsstream": "^1.6"
     },
     "scripts": {
         "phpstan": "phpstan analyse -c phpstan.neon",
         "phpstan-baseline": "phpstan analyse -c phpstan.neon --generate-baseline",
-        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating"
+        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -57,17 +57,21 @@ class RunRegressionCommand extends Command
         }
 
         if (!$input->getArgument('productVersion')) {
-            $productVersion = $io->ask('Please enter the Ibexa DXP version', '4.1', static function (string $answer): string {
-                if (preg_match('/^(\d+)\.(\d+)$/', $answer) === 0) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'Unrecognised version format: %s. Please use format X.Y instead, e.g. 3.3, 4.0, 4.1',
-                        $answer)
-                    );
-                }
+            $productVersion = $io->ask(
+                'Please enter the Ibexa DXP version',
+                '4.2',
+                static function (string $answer): string {
+                    if (preg_match('/^(\d+)\.(\d+)$/', $answer) === 0) {
+                        throw new \RuntimeException(
+                            sprintf(
+                                'Unrecognised version format: %s. Please use format X.Y instead, e.g. 3.3, 4.2, 4.3',
+                                $answer)
+                        );
+                    }
 
-                return $answer;
-            });
+                    return $answer;
+                }
+            );
 
             $input->setArgument('productVersion', $productVersion);
         }
@@ -145,7 +149,9 @@ class RunRegressionCommand extends Command
 
         $this->waitUntilBranchExists($productEdition, $regressionBranchName);
 
-        $response = $this->githubClient->pullRequests()->create(self::REPO_OWNER, $productEdition,
+        $response = $this->githubClient->pullRequests()->create(
+            self::REPO_OWNER,
+            $productEdition,
             [
                 'title' => 'Run regression for IBX-XXXX',
                 'base' => $baseBranch,

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -6,12 +6,12 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Platform\ContiniousIntegrationScripts\Command;
+namespace Ibexa\ContiniousIntegrationScripts\Command;
 
-use Cz\Git\GitException;
-use Cz\Git\GitRepository;
+use CzProject\GitPhp\Git;
+use CzProject\GitPhp\GitException;
 use Github\Client;
-use Ibexa\Platform\ContiniousIntegrationScripts\Helper\ComposerHelper;
+use Ibexa\ContiniousIntegrationScripts\Helper\ComposerLocalTokenProvider;
 use JsonException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -31,12 +31,29 @@ class RunRegressionCommand extends Command
     /** @var ?string */
     private $token;
 
+    /** @var \Github\Client */
+    private $githubClient;
+
+    /** @var \CzProject\GitPhp\Git */
+    private $repository;
+
+    /** @var \Ibexa\ContiniousIntegrationScripts\Helper\ComposerLocalTokenProvider */
+    private $tokenProvider;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->githubClient = new Client();
+        $this->repository = new Git();
+        $this->tokenProvider = new ComposerLocalTokenProvider();
+    }
+
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $io = new SymfonyStyle($input, $output);
 
         if (!$input->getArgument('token')) {
-            $input->setArgument('token', ComposerHelper::getGitHubToken());
+            $input->setArgument('token', $this->tokenProvider->getGitHubToken());
         }
 
         if (!$input->getArgument('productVersion')) {
@@ -99,13 +116,13 @@ class RunRegressionCommand extends Command
     private function createRegressionPullRequest(string $productEdition, string $baseBranch, string $regressionBranchName, SymfonyStyle $io): void
     {
         try {
-            $repo = GitRepository::cloneRepository(
+            $repo = $this->repository->cloneRepository(
                 sprintf('git@github.com:%s/%s.git', self::REPO_OWNER, $productEdition),
                 null, ['-b' => $baseBranch]
             );
         } catch (GitException $exception) {
             // fallback to HTTPS if SSH fails
-            $repo = GitRepository::cloneRepository(
+            $repo = $this->repository->cloneRepository(
                 sprintf('https://github.com/%s/%s.git', self::REPO_OWNER, $productEdition),
                 null, ['-b' => $baseBranch]
             );
@@ -118,18 +135,17 @@ class RunRegressionCommand extends Command
 
         $repo->addFile(LinkDependenciesCommand::DEPENDENCIES_FILE);
         $repo->commit(self::COMMIT_MESSAGE);
-        $repo->push('origin', [$regressionBranchName, '-u']);
+        $repo->push(['origin', $regressionBranchName]);
 
         $io->success(sprintf('Successfuly pushed to %s/%s a branch called: %s', self::REPO_OWNER, $productEdition, $regressionBranchName));
 
-        $client = new Client();
         if ($this->token) {
-            $client->authenticate($this->token, null, Client::AUTH_ACCESS_TOKEN);
+            $this->githubClient->authenticate($this->token, null, Client::AUTH_ACCESS_TOKEN);
         }
 
-        $this->waitUntilBranchExists($client, $productEdition, $regressionBranchName);
+        $this->waitUntilBranchExists($productEdition, $regressionBranchName);
 
-        $response = $client->pullRequests()->create(self::REPO_OWNER, $productEdition,
+        $response = $this->githubClient->pullRequests()->create(self::REPO_OWNER, $productEdition,
             [
                 'title' => 'Run regression for IBX-XXXX',
                 'base' => $baseBranch,
@@ -181,13 +197,13 @@ class RunRegressionCommand extends Command
         }
     }
 
-    private function waitUntilBranchExists(Client $client, string $productEdition, string $branchName): void
+    private function waitUntilBranchExists(string $productEdition, string $branchName): void
     {
         $counter = 0;
         $success = false;
         while ($counter < 5) {
             try {
-                $client->repo()->branches(self::REPO_OWNER, $productEdition, $branchName);
+                $this->githubClient->repo()->branches(self::REPO_OWNER, $productEdition, $branchName);
                 $success = true;
                 break;
             } catch (\RuntimeException $e) {
@@ -203,6 +219,6 @@ class RunRegressionCommand extends Command
 
     private function getBaseBranch(string $productVersion): string
     {
-        return $productVersion === "4.2" ? "master" : $productVersion;
+        return $productVersion === '4.2' ? 'master' : $productVersion;
     }
 }

--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -219,6 +219,6 @@ class RunRegressionCommand extends Command
 
     private function getBaseBranch(string $productVersion): string
     {
-        return $productVersion === '4.2' ? 'master' : $productVersion;
+        return $productVersion === '4.3' ? 'master' : $productVersion;
     }
 }

--- a/src/Helper/ComposerLocalTokenProvider.php
+++ b/src/Helper/ComposerLocalTokenProvider.php
@@ -13,9 +13,9 @@ class ComposerLocalTokenProvider
     public function getGitHubToken(): ?string
     {
         $output = [];
-        $result_code = 0;
-        exec('composer config github-oauth.github.com --global 2> /dev/null', $output, $result_code);
+        $resultCode = 0;
+        exec('composer config github-oauth.github.com --global 2> /dev/null', $output, $resultCode);
 
-        return $result_code === 0 ? $output[0] : null;
+        return $resultCode === 0 ? $output[0] : null;
     }
 }

--- a/src/Helper/ComposerLocalTokenProvider.php
+++ b/src/Helper/ComposerLocalTokenProvider.php
@@ -6,11 +6,11 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Platform\ContiniousIntegrationScripts\Helper;
+namespace Ibexa\ContiniousIntegrationScripts\Helper;
 
-class ComposerHelper
+class ComposerLocalTokenProvider
 {
-    public static function getGitHubToken(): ?string
+    public function getGitHubToken(): ?string
     {
         $output = [];
         $result_code = 0;

--- a/src/ValueObject/ComposerPullRequestData.php
+++ b/src/ValueObject/ComposerPullRequestData.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Platform\ContiniousIntegrationScripts\ValueObject;
+namespace Ibexa\ContiniousIntegrationScripts\ValueObject;
 
 class ComposerPullRequestData
 {

--- a/src/ValueObject/Dependencies.php
+++ b/src/ValueObject/Dependencies.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Platform\ContiniousIntegrationScripts\ValueObject;
+namespace Ibexa\ContiniousIntegrationScripts\ValueObject;
 
 class Dependencies
 {

--- a/tests/Command/LinkDependenciesCommandTest.php
+++ b/tests/Command/LinkDependenciesCommandTest.php
@@ -22,6 +22,26 @@ class LinkDependenciesCommandTest extends TestCase
     /** @var \Symfony\Component\Console\Tester\CommandTester */
     private $commandTester;
 
+    private const EXPECTED_FILE_CONTENT = <<<FILE
+    {
+        "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-24",
+        "packages": [
+            {
+                "requirement": "dev-temp_2.3_to_4.2 as 4.2.x-dev",
+                "repositoryUrl": "https://github.com/ibexa/admin-ui",
+                "package": "ibexa/admin-ui",
+                "shouldBeAddedAsVCS": false
+            },
+            {
+                "requirement": "dev-known-issue-message as 4.3.x-dev",
+                "repositoryUrl": "https://github.com/ibexa/behat",
+                "package": "ibexa/behat",
+                "shouldBeAddedAsVCS": false
+            }
+        ]
+    }
+    FILE;
+
     /** @var \org\bovigo\vfs\vfsStreamDirectory */
     private $fileSystemRoot;
 
@@ -30,7 +50,9 @@ class LinkDependenciesCommandTest extends TestCase
         $tokenProvider = $this->createMock(ComposerLocalTokenProvider::class);
         $tokenProvider->method('getGithubToken')->willReturn(null);
         $this->fileSystemRoot = vfsStream::setup();
-        $this->commandTester = new CommandTester(new LinkDependenciesCommand($this->fileSystemRoot->url(), $tokenProvider));
+        $this->commandTester = new CommandTester(
+            new LinkDependenciesCommand($this->fileSystemRoot->url(), $tokenProvider)
+        );
     }
 
     public function testGeneratesCorrectDependenciesJsonFile(): void
@@ -45,24 +67,9 @@ class LinkDependenciesCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         Assert::assertTrue($this->fileSystemRoot->hasChild(self::FILENAME));
-        Assert::assertEquals(<<<FILE
-{
-    "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-24",
-    "packages": [
-        {
-            "requirement": "dev-temp_2.3_to_4.2 as 4.2.x-dev",
-            "repositoryUrl": "https://github.com/ibexa/admin-ui",
-            "package": "ibexa/admin-ui",
-            "shouldBeAddedAsVCS": false
-        },
-        {
-            "requirement": "dev-known-issue-message as 4.3.x-dev",
-            "repositoryUrl": "https://github.com/ibexa/behat",
-            "package": "ibexa/behat",
-            "shouldBeAddedAsVCS": false
-        }
-    ]
-}
-FILE, file_get_contents($this->fileSystemRoot->getChild(self::FILENAME)->url()));
+        Assert::assertEquals(
+            self::EXPECTED_FILE_CONTENT,
+            file_get_contents($this->fileSystemRoot->getChild(self::FILENAME)->url())
+        );
     }
 }

--- a/tests/Command/LinkDependenciesCommandTest.php
+++ b/tests/Command/LinkDependenciesCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Ibexa\Tests\ContiniousIntegrationScripts\Command;
+
+use Ibexa\ContiniousIntegrationScripts\Command\LinkDependenciesCommand;
+use Ibexa\ContiniousIntegrationScripts\Helper\ComposerLocalTokenProvider;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class LinkDependenciesCommandTest extends TestCase
+{
+    private const FILENAME = 'dependencies.json';
+
+    /** @var \Symfony\Component\Console\Tester\CommandTester */
+    private $commandTester;
+
+    /** @var \org\bovigo\vfs\vfsStreamDirectory */
+    private $fileSystemRoot;
+
+    protected function setUp(): void
+    {
+        $tokenProvider = $this->createMock(ComposerLocalTokenProvider::class);
+        $tokenProvider->method('getGithubToken')->willReturn(null);
+        $this->fileSystemRoot = vfsStream::setup();
+        $this->commandTester = new CommandTester(new LinkDependenciesCommand($this->fileSystemRoot->url(), $tokenProvider));
+    }
+
+    public function testGeneratesCorrectDependenciesJsonFile(): void
+    {
+        $this->commandTester->setInputs([
+            '3',
+            'https://github.com/ibexa/admin-ui/pull/577',
+            'https://github.com/ibexa/recipes-dev/pull/24',
+            'https://github.com/ibexa/behat/pull/37',
+        ]);
+
+        $this->commandTester->execute([]);
+
+        Assert::assertTrue($this->fileSystemRoot->hasChild(self::FILENAME));
+        Assert::assertEquals(<<<FILE
+{
+    "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-24",
+    "packages": [
+        {
+            "requirement": "dev-temp_2.3_to_4.2 as 4.2.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/admin-ui",
+            "package": "ibexa/admin-ui",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-known-issue-message as 4.3.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/behat",
+            "package": "ibexa/behat",
+            "shouldBeAddedAsVCS": false
+        }
+    ]
+}
+FILE, file_get_contents($this->fileSystemRoot->getChild(self::FILENAME)->url()));
+    }
+}

--- a/tests/Command/LinkDependenciesCommandTest.php
+++ b/tests/Command/LinkDependenciesCommandTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\ContiniousIntegrationScripts\Command;
 
 use Ibexa\ContiniousIntegrationScripts\Command\LinkDependenciesCommand;

--- a/tests/Command/RunRegressionCommandTest.php
+++ b/tests/Command/RunRegressionCommandTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Ibexa\Tests\ContiniousIntegrationScripts\Command;
+
+use Ibexa\ContiniousIntegrationScripts\Command\RunRegressionCommand;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class RunRegressionCommandTest extends TestCase
+{
+    public function testIsInitializable(): void
+    {
+        Assert::assertInstanceOf(RunRegressionCommand::class, new RunRegressionCommand());
+    }
+}

--- a/tests/Command/RunRegressionCommandTest.php
+++ b/tests/Command/RunRegressionCommandTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\ContiniousIntegrationScripts\Command;
 
 use Ibexa\ContiniousIntegrationScripts\Command\RunRegressionCommand;


### PR DESCRIPTION
This PR fixed the issues after https://github.com/ibexa/ci-scripts/pull/59

Because I was adding a new namespace for tests I've decided to get rid of the `Platform` part in all classes - to make it consistent with other DXP packages.

I was able to write a meaningful test for the LinkDependenciesCommand, which tests the Command output.
For RunRegressionCommand I was not able to find the right balance - the Command does many interactions (Github API, filesystem changes, git repository changes) that require mocking all dependencies, which would result in a test very strictly coupled with the implementation. The test I've ended up adding would detect the issue that this PR fixes.

Also https://github.com/ibexa/ci-scripts/pull/60/commits/e1f1024b0967e5cce2b302fef3db98a99d909bc3 fixes small issue related to stable branches.