### PR TITLE
Removed hardcoded productVersion logic

### DIFF
--- a/src/Command/RunRegressionCommand.php
+++ b/src/Command/RunRegressionCommand.php
@@ -107,10 +107,10 @@ class RunRegressionCommand extends Command
 
         $this->validate();
 
-        $baseBranch = $this->getBaseBranch($productVersion);
         $regressionBranchName = uniqid('tmp_regression_', true);
 
         foreach ($productEditions as $productEdition) {
+            $baseBranch = $this->getBaseBranch($productEdition, $productVersion);
             $this->createRegressionPullRequest($productEdition, $baseBranch, $regressionBranchName, $io);
         }
 
@@ -223,8 +223,14 @@ class RunRegressionCommand extends Command
         }
     }
 
-    private function getBaseBranch(string $productVersion): string
+    private function getBaseBranch($productEdition, string $productVersion): string
     {
-        return $productVersion === '4.3' ? 'master' : $productVersion;
+        try {
+            $this->githubClient->repo()->branches(self::REPO_OWNER, $productEdition, $productVersion);
+
+            return $productVersion;
+        } catch (\RuntimeException $e) {
+            return 'master';
+        }
     }
 }


### PR DESCRIPTION
Instead of having the logic hardcoded we ask GitHub whether the `productVersion` branch exists in the repository - if it does then we will use it, otherwise we will default to `master`.

Tested locally, the `string(6) "master"` shows which branch will be used.
```
~/Desktop/repos/ci-scripts on remove-hardcoded-version !1 ?2 ❯ bin/ci regression:run                                                                                                                       took 4m 4s  14.17.0 at 10:09:12

 Please enter the Ibexa DXP version [4.2]:
 > 4.2

 Please enter the Ibexa DXP edition(s) [oss]:
 > oss

string(3) "4.2"
~/Desktop/repos/ci-scripts on remove-hardcoded-version !1 ?2 ❯ bin/ci regression:run                                                                                                                          took 6s  14.17.0 at 10:09:46

 Please enter the Ibexa DXP version [4.2]:
 > 4.3

 Please enter the Ibexa DXP edition(s) [oss]:
 > oss

string(6) "master"
~/Desktop/repos/ci-scripts on remove-hardcoded-version !1 ?2 ❯ bin/ci regression:run                                                                                                                          took 3s  14.17.0 at 10:09:51

 Please enter the Ibexa DXP version [4.2]:
 > 3.3

 Please enter the Ibexa DXP edition(s) [oss]:
 > oss

string(3) "3.3"
~/Desktop/repos/ci-scripts on remove-hardcoded-version !1 ?2 ❯ bin/ci regression:run                                                                                                                         took 13s  14.17.0 at 10:10:05

 Please enter the Ibexa DXP version [4.2]:
 > 4.3

 Please enter the Ibexa DXP edition(s) [oss]:
 > content

string(6) "master"
~/Desktop/repos/ci-scripts on remove-hardcoded-version !1 ?2 ❯ bin/ci regression:run                                                                                                                          took 5s  14.17.0 at 10:10:12

 Please enter the Ibexa DXP version [4.2]:
 > 4.4

 Please enter the Ibexa DXP edition(s) [oss]:
 > content

string(6) "master"
```