### PR TITLE
Added visual testing

### DIFF
--- a/bin/4.3.x-dev/prepare_project_edition.sh
+++ b/bin/4.3.x-dev/prepare_project_edition.sh
@@ -140,6 +140,11 @@ cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 docker container stop install_dependencies
 docker container rm install_dependencies
 
+# Set up Percy visual testing base branch
+IFS='.' read -ra VERSION_NUMBERS <<< "$PROJECT_VERSION"
+VERSION="${VERSION_NUMBERS[0]}.${VERSION_NUMBERS[1]}/$PROJECT_EDITION"
+export PERCY_BRANCH=$VERSION
+
 echo "> Start docker containers specified by ${COMPOSE_FILE}"
 docker-compose --env-file=.env up -d
 

--- a/bin/4.3.x-dev/prepare_project_edition.sh
+++ b/bin/4.3.x-dev/prepare_project_edition.sh
@@ -99,6 +99,7 @@ JSON_STRING=$( jq -n \
                   '{"type": "path", "url": $packageDir, "options": { "symlink": false , "versions": { ($packageName): $packageVersion}}}' )
 
 composer config repositories.localDependency "$JSON_STRING"
+composer require "$DEPENDENCY_PACKAGE_NAME:$DEPENDENCY_PACKAGE_VERSION" --no-update
 
 # Install Behat and Docker packages
 docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --no-update --ansi

--- a/bin/4.4.x-dev/prepare_project_edition.sh
+++ b/bin/4.4.x-dev/prepare_project_edition.sh
@@ -99,6 +99,7 @@ JSON_STRING=$( jq -n \
                   '{"type": "path", "url": $packageDir, "options": { "symlink": false , "versions": { ($packageName): $packageVersion}}}' )
 
 composer config repositories.localDependency "$JSON_STRING"
+composer require "$DEPENDENCY_PACKAGE_NAME:$DEPENDENCY_PACKAGE_VERSION" --no-update
 
 # Install Behat and Docker packages
 docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --no-update --ansi
@@ -139,6 +140,11 @@ cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies
+
+# Set up Percy visual testing base branch
+IFS='.' read -ra VERSION_NUMBERS <<< "$PROJECT_VERSION"
+VERSION="${VERSION_NUMBERS[0]}.${VERSION_NUMBERS[1]}/$PROJECT_EDITION"
+export PERCY_BRANCH=$VERSION
 
 echo "> Start docker containers specified by ${COMPOSE_FILE}"
 docker-compose --env-file=.env up -d


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3902

This PR adds two things:
1) Package requesting the setup will be always added to composer.json (triggering a build from ibexa/visual-testing will cause it to be added to composer.json and installed automatically)
2) Percy env variable is set, based on project edition and version (commerce ^4.3.x-dev -> 4.3/commerce)