### PR TITLE
[Releases builds] Use freshly tagged Behat version

### DIFF
--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -48,7 +48,7 @@ if [[ $PROJECT_VERSION == *"v3.3"* ]]; then
     docker exec install_dependencies composer require ezsystems/behatbundle:^8.3 ibexa/docker:$PROJECT_VERSION --no-scripts
 else
     echo "> Installing dependencies for v4"
-    docker exec install_dependencies composer require ibexa/behat:^4.0 ibexa/docker:$PROJECT_VERSION --no-scripts
+    docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts
 fi
 
 # Enable FriendsOfBehat SymfonyExtension in the Behat env


### PR DESCRIPTION
We're tagging the `ibexa/behat` package with every release - we can take advantage of that and avoid hardcoding it.

Also it narrows the available packages for Composer, making its job easier.