### PR TITLE
Seperated search indexing from database installation

### DIFF
--- a/bin/4.3.x-dev/prepare_project_edition.sh
+++ b/bin/4.3.x-dev/prepare_project_edition.sh
@@ -159,7 +159,8 @@ echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd --ansi"
 
 echo '> Install data'
-docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
 echo '> Generate GraphQL schema'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"

--- a/bin/4.4.x-dev/prepare_project_edition.sh
+++ b/bin/4.4.x-dev/prepare_project_edition.sh
@@ -159,7 +159,8 @@ echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd --ansi"
 
 echo '> Install data'
-docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
 echo '> Generate GraphQL schema'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -152,7 +152,8 @@ echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd --ansi"
 
 echo '> Install data'
-docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
 echo '> Generate GraphQL schema'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -74,7 +74,8 @@ echo '> Clear cache & generate assets'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd --ansi"
 
 echo '> Install data'
-docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing"
+docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
 echo '> Generate GraphQL schema'
 docker-compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"


### PR DESCRIPTION
Needed for https://github.com/ibexa/visual-testing/pull/2 and tested there

For some reason the setup steps fails with:
```
  152/152 [============================] 100%
In App_KernelBehatDebugContainer.php line 3272:
                                                                               
  Warning: require(/var/www/var/cache/behat/ContainerBXxHz3B/getSwiftmailer_E  
  mailSender_ListenerService.php): failed to open stream: No such file or dir  
  ectory                                                                       
                                                                               

ibexa:install [--skip-indexing] [--siteaccess [SITEACCESS]] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi|--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] [<type>]
```
(https://github.com/ibexa/visual-testing/actions/runs/3649183970/jobs/6164540855)

Which seems strange, because the file is for sure there - I think we're hitting the system limit of opened files and that's why it fails (not 100% sure TBH 🤔 )

Splitting the installation process into 2 steps: "pure DB install" and indexing helps with the issue, tested in:
https://github.com/ibexa/visual-testing/pull/2