### PR TITLE
Moved ibexa/behat and ibexa/docker installation

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -101,9 +101,6 @@ JSON_STRING=$( jq -n \
 composer config repositories.localDependency "$JSON_STRING"
 composer require "$DEPENDENCY_PACKAGE_NAME:$DEPENDENCY_PACKAGE_VERSION" --no-update
 
-# Install Behat and Docker packages
-docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --no-update --ansi
-
 # Add other dependencies if required
 if [ -f dependencies.json ]; then
     COUNT=$(cat dependencies.json | jq '.packages | length' )
@@ -127,6 +124,9 @@ docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PRO
 git init; git add . > /dev/null;
 # Execute recipes
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
+
+# Install Behat and Docker packages
+docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi
 
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php


### PR DESCRIPTION
Both doctrine/doctrine-bundle and ibexa/docker define the database credentials in `.env`:
```
###> doctrine/doctrine-bundle ###
# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
#
# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
# DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
###< doctrine/doctrine-bundle ###
```

```
###> ibexa/docker ###
# Database configuration for Docker
DATABASE_USER=ezp
DATABASE_PASSWORD=SetYourOwnPassword
DATABASE_NAME=ezp
DATABASE_HOST=db
DATABASE_PORT=3306
DATABASE_PLATFORM=mysql
DATABASE_DRIVER=pdo_mysql
# Needed by Doctrine Bundle / ORM to avoid it opening connection during situations where there is no service yet.
# See: https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration
DATABASE_VERSION=mariadb-10.3.0
DATABASE_URL=${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?serverVersion=${DATABASE_VERSION}
###< ibexa/docker ###
```

Only the last entry in `.env` is taken into account - that's why the recipe for ibexa/docker needs to be executed later than the doctrine-bundle one.

This fixes the issue I had in https://github.com/ibexa/visual-testing/pull/15 - the correct database credentials will be taken into account.

I had to remove the `--no-update` flag - in the previous version the packages were installed together with the edition, right now we're installing them separately (this ensures the correct recipe order).