### PR TITLE
Marked /var/www as safe directory for Git

### DIFF
--- a/bin/4.5.x-dev/prepare_project_edition.sh
+++ b/bin/4.5.x-dev/prepare_project_edition.sh
@@ -123,8 +123,10 @@ fi
 
 # Install correct product variant
 docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
+
 # Init a repository to avoid Composer asking questions
-git init; git add . > /dev/null;
+docker exec install_dependencies git config --global --add safe.directory /var/www && git init && git add .
+
 # Execute recipes
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
 

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -120,8 +120,10 @@ fi
 
 # Install correct product variant
 docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
+
 # Init a repository to avoid Composer asking questions
-git init; git add . > /dev/null;
+docker exec install_dependencies git config --global --add safe.directory /var/www && git init && git add .
+
 # Execute recipes
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
 

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -121,8 +121,10 @@ fi
 
 # Install correct product variant
 docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
+
 # Init a repository to avoid Composer asking questions
-git init; git add . > /dev/null;
+docker exec install_dependencies git config --global --add safe.directory /var/www && git init && git add .
+
 # Execute recipes
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
 


### PR DESCRIPTION
This PR solves the issues with the latest Docker images we had (https://github.com/ibexa/headless/pull/3)

The newer images have newer Git version, which contains new security setting. More information:
https://github.blog/2022-04-12-git-security-vulnerability-announced/
https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git

Without marking the /var/www dir as safe the git operations fail (silently! which is the worst part) - and without a working git repository the recipes installation fails as well (recipes are not applied).

Tested in https://github.com/ibexa/headless/pull/4