### PR TITLE
Moved adding dependencies to the last part of installation phase

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -101,6 +101,18 @@ JSON_STRING=$( jq -n \
 composer config repositories.localDependency "$JSON_STRING"
 composer require "$DEPENDENCY_PACKAGE_NAME:$DEPENDENCY_PACKAGE_VERSION" --no-update
 
+# Install correct product variant
+docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
+
+# Init a repository to avoid Composer asking questions
+docker exec install_dependencies git config --global --add safe.directory /var/www && git init && git add .
+
+# Execute recipes
+docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
+
+# Install Behat and Docker packages
+docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi
+
 # Add other dependencies if required
 if [ -f dependencies.json ]; then
     COUNT=$(cat dependencies.json | jq '.packages | length' )
@@ -116,19 +128,12 @@ if [ -f dependencies.json ]; then
         jq --arg package "$PACKAGE_NAME" --arg requirement "$REQUIREMENT" '.["require"] += { ($package) : ($requirement) }' composer.json > composer.json.new
         mv composer.json.new composer.json
     done
+    docker exec install_dependencies composer update --no-scripts
+
+    # Execute Behat and Docker recipes again
+    docker exec install_dependencies composer recipes:install ibexa/behat --force --reset --ansi
+    docker exec install_dependencies composer recipes:install ibexa/docker --force --reset --ansi
 fi
-
-# Install correct product variant
-docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
-
-# Init a repository to avoid Composer asking questions
-docker exec install_dependencies git config --global --add safe.directory /var/www && git init && git add .
-
-# Execute recipes
-docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
-
-# Install Behat and Docker packages
-docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi
 
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -111,7 +111,7 @@ docker exec install_dependencies git config --global --add safe.directory /var/w
 docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITION} --force --reset --ansi
 
 # Install Behat and Docker packages
-docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi
+docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi --no-update
 
 # Add other dependencies if required
 if [ -f dependencies.json ]; then
@@ -128,12 +128,9 @@ if [ -f dependencies.json ]; then
         jq --arg package "$PACKAGE_NAME" --arg requirement "$REQUIREMENT" '.["require"] += { ($package) : ($requirement) }' composer.json > composer.json.new
         mv composer.json.new composer.json
     done
-    docker exec install_dependencies composer update --no-scripts
-
-    # Execute Behat and Docker recipes again
-    docker exec install_dependencies composer recipes:install ibexa/behat --force --reset --ansi
-    docker exec install_dependencies composer recipes:install ibexa/docker --force --reset --ansi
 fi
+
+docker exec install_dependencies composer update --no-scripts
 
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php


### PR DESCRIPTION
Problem:

it's not currently possible to add a dependency (using dependencies.json) for `ibexa/behat` and `ibexa/docker` packages:
they are added during the "adding dependencies" phase, but after this phase they are added again (in the 4.6.x-dev version).

Example affected build: https://github.com/ibexa/commerce/actions/runs/5900504035/job/16004881059

You can see that the dependency is downgraded:
![obraz](https://github.com/ibexa/ci-scripts/assets/10993858/c18668ec-33d8-4418-9734-6636b2aa3642)

Only 4.6 is affected, this is a bug I've added in https://github.com/ibexa/ci-scripts/pull/73

My solution is to move the phases around:
1) Add the `behat` and `docker` packages first (with `--no-update`)
2) Add the dependencies (again with `--no-update`)
3) Install the dependencies (`composer update --no-scripts`)

Tested in:
https://github.com/ibexa/commerce/pull/348
https://github.com/ibexa/taxonomy/pull/40
