### PR TITLE
PHP 8.2: Add custom error handler if needed

### DIFF
--- a/bin/4.5.x-dev/prepare_project_edition.sh
+++ b/bin/4.5.x-dev/prepare_project_edition.sh
@@ -136,6 +136,7 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 if [[ $PHP_IMAGE == *"8.2"* ]]; then
     echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+    docker exec install_dependencies composer dump-autoload
 fi
 
 echo "> Display composer.json for debugging"

--- a/bin/4.5.x-dev/prepare_project_edition.sh
+++ b/bin/4.5.x-dev/prepare_project_edition.sh
@@ -133,6 +133,11 @@ docker exec install_dependencies composer recipes:install ibexa/${PROJECT_EDITIO
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
 
+if [[ $PHP_IMAGE == *"8.2"* ]]; then
+    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+fi
+
 echo "> Display composer.json for debugging"
 cat composer.json
 

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -135,6 +135,11 @@ docker exec install_dependencies composer update --no-scripts
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
 
+if [[ $PHP_IMAGE == *"8.2"* ]]; then
+    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+fi
+
 echo "> Display composer.json for debugging"
 cat composer.json
 

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -138,6 +138,7 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 if [[ $PHP_IMAGE == *"8.2"* ]]; then
     echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+    docker exec install_dependencies composer dump-autoload
 fi
 
 echo "> Display composer.json for debugging"

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -134,6 +134,11 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
+if [[ $PHP_IMAGE == *"8.2"* ]]; then
+    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+fi
+
 echo "> Display composer.json for debugging"
 cat composer.json
 

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -137,6 +137,7 @@ cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 if [[ $PHP_IMAGE == *"8.2"* ]]; then
     echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+    docker exec install_dependencies composer dump-autoload
 fi
 
 echo "> Display composer.json for debugging"

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -56,6 +56,11 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
+if [[ $PHP_IMAGE == *"8.2"* ]]; then
+    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+fi
+
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -59,6 +59,7 @@ cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 if [[ $PHP_IMAGE == *"8.2"* ]]; then
     echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
+    docker exec install_dependencies composer dump-autoload
 fi
 
 # Depenencies are installed and container can be removed


### PR DESCRIPTION
Requires: https://github.com/ezsystems/ezplatform-kernel/pull/386

This uses Sławek's work to disable PHP 8.2 deprecations on CI - this will allow us to add PHP 8.2 to the matrix.

Doc:
https://symfony.com/doc/current/components/runtime.html (the autoload part is needed because only then the vendor/autoload_runtime.php file is modified)

Tested in https://github.com/ibexa/commerce/pull/412