### PR TITLE
Fixed builds when a package has dependencies on other branches

### DIFF
--- a/bin/4.5.x-dev/prepare_project_edition.sh
+++ b/bin/4.5.x-dev/prepare_project_edition.sh
@@ -121,6 +121,9 @@ if [ -f dependencies.json ]; then
     done
 fi
 
+echo "> Display composer.json for debugging"
+cat composer.json
+
 # Install correct product variant
 docker exec install_dependencies composer require ibexa/${PROJECT_EDITION}:${PROJECT_VERSION} -W --no-scripts --ansi
 


### PR DESCRIPTION
Current situation:
When the composer.json is modified to include dependencies on other branches then the dependencies.json is not enough to run the Browser tests - the build will fail before the file is even parsed. 

This PR moves the parsing of `dependencies.json` before the Ibexa main package (oss, headless, experience, commerce) is added so that Composer is aware that additional dev packages will be needed.

Example failure:
https://github.com/ibexa/rest/actions/runs/7287087802/job/19857028341?pr=82

TODO:
1) Check that it works in normal regression builds
2) Check that it works when a PR with modified composer.json is included in a regression
3) Copy the solution to other scripts (3.3, 4.5)