### PR TITLE
Bump 5.0 default image to PHP 8.3

### DIFF
--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -5,7 +5,7 @@ PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 PROJECT_BUILD_DIR=${HOME}/build/project
 export COMPOSE_FILE=$3
-export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.1-node18}
+export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.3-node18}
 export COMPOSER_MAX_PARALLEL_HTTP=6 # Reduce Composer parallelism to work around Github Actions network errors
 
 if [[ -n "${DOCKER_PASSWORD}" ]]; then


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
To unblock work on setting PHP 8.3 as minimum and default for v5.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
