### PR TITLE
IBX-8422: Update scripts for PHP 8.3 as default when releasing tags

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -5,7 +5,7 @@ PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 PROJECT_BUILD_DIR=${HOME}/build/project
 export COMPOSE_FILE=$3
-export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.1-node18}
+export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.3-node18}
 export COMPOSER_MAX_PARALLEL_HTTP=6 # Reduce Composer parallelism to work around Github Actions network errors
 
 if [[ -n "${DOCKER_PASSWORD}" ]]; then

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -137,7 +137,7 @@ docker exec install_dependencies composer update --no-scripts
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
 
 if [[ $PHP_IMAGE == *"8.2"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    echo "> Set PHP 8.2+ Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
     docker exec install_dependencies composer dump-autoload
 fi

--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -137,7 +137,7 @@ docker exec install_dependencies composer update --no-scripts
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
 
 if [[ $PHP_IMAGE == *"8.2"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    echo "> Set PHP 8.2+ Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
     docker exec install_dependencies composer dump-autoload
 fi

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -5,7 +5,7 @@ PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 PROJECT_BUILD_DIR=${HOME}/build/project
 export COMPOSE_FILE=$3
-export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.1-node18}
+export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.3-node18}
 export COMPOSER_MAX_PARALLEL_HTTP=6 # Reduce Composer parallelism to work around Github Actions network errors
 
 if [[ -n "${DOCKER_PASSWORD}" ]]; then

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -35,11 +35,11 @@ if [ -f ${DEPENDENCY_PACKAGE_DIR}/auth.json ]; then
 fi
 
 if [[ $PHP_IMAGE == *"7."* ]] || [[ $PHP_IMAGE == *"8.0"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Running composer update"
-    docker exec install_dependencies composer update --no-scripts --ansi
-else
     echo "> Running composer install"
     docker exec install_dependencies composer install --no-scripts --ansi
+else
+    echo "> Running composer update"
+    docker exec install_dependencies composer update --no-scripts --ansi
 fi
 
 if [[ $PROJECT_VERSION == *"v3.3"* ]]; then

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -57,7 +57,7 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
 if [[ $PHP_IMAGE == *"8.2"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Set PHP 8.2 Ibexa error handler to avoid deprecations"
+    echo "> Set PHP 8.2+ Ibexa error handler to avoid deprecations"
     docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
     docker exec install_dependencies composer dump-autoload
 fi

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -5,7 +5,7 @@ PROJECT_EDITION=$1
 PROJECT_VERSION=$2
 PROJECT_BUILD_DIR=${HOME}/build/project
 export COMPOSE_FILE=$3
-export PHP_IMAGE=${4-ezsystems/php:7.4-v2-node16}
+export PHP_IMAGE=${4-ghcr.io/ibexa/docker/php:8.3-node18}
 export COMPOSER_MAX_PARALLEL_HTTP=6 # Reduce Composer parallelism to work around Github Actions network errors
 
 DEPENDENCY_PACKAGE_DIR=$(pwd)

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -56,12 +56,6 @@ sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/
 # Create a default Behat configuration file
 cp "behat_ibexa_${PROJECT_EDITION}.yaml" behat.yaml
 
-if [[ $PHP_IMAGE == *"8.2"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Set PHP 8.2+ Ibexa error handler to avoid deprecations"
-    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
-    docker exec install_dependencies composer dump-autoload
-fi
-
 # Depenencies are installed and container can be removed
 docker container stop install_dependencies
 docker container rm install_dependencies

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -34,7 +34,7 @@ if [ -f ${DEPENDENCY_PACKAGE_DIR}/auth.json ]; then
     cp ${DEPENDENCY_PACKAGE_DIR}/auth.json .
 fi
 
-if [[ $PHP_IMAGE == *"7."* ]] || [[ $PHP_IMAGE == *"8.0"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
+if [[ $PHP_IMAGE == *"8.3"* ]]; then
     echo "> Running composer install"
     docker exec install_dependencies composer install --no-scripts --ansi
 else


### PR DESCRIPTION
| :ticket: Issue | IBX-8422 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

Things to double-check:

1. Presence of error handler hiding deprecations from PHP 8.2 up in all scripts
2. Default PHP 8.3 image (covered for majority of places in https://github.com/ibexa/gh-workflows/pull/51)
3. Sequence of composer commands (https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp/#create-project) in stable script

TODO:
- [x] decide about `PHP_IMAGE` for "stable" directory (https://github.com/ibexa/ci-scripts/pull/91/commits/7c34f26868d9fca60a26bcec40da3637553c4a73)

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
