### PR TITLE
Simplified autoload in ./bin/ci script

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,24 +1,15 @@
 #!/usr/bin/env php
 <?php
 
-if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
-    require $autoload;
+$autoload = dirname(__DIR__) . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+    fwrite(
+        STDERR,
+        'You must run composer install to setup your dependencies. See https://getcomposer.org/download/ for more information.' . PHP_EOL
+    );
+    exit(1);
 }
-
-if (!class_exists('Symfony\Component\Console\Application', true)) {
-    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-        require($autoload);
-    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-        require($autoload);
-    } else {
-        fwrite(STDERR,
-            'You must set up the project dependencies, run the following commands:'.PHP_EOL.
-            'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-            'php composer.phar install'.PHP_EOL
-        );
-        exit(1);
-    }
-}
+require_once $autoload;
 
 $application = new Symfony\Component\Console\Application;
 


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:
I've noticed that calling `./bin/ci` Symfony commands wrapper outside of the package itself doesn't work, which is a bit inconvenient, since it's a standalone tool.
It happens because we're using `getcwd()` - "get current working directory", while there's a simpler way to refer to autoload file - `__DIR__`. This PR fixes that.

#### For QA:

Run `./bin/ci dependencies:link` and `regression:run`.

