### PR TITLE
IBX-8959: Included AI packages in all PHP versions on v4.6

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -116,7 +116,6 @@ docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION i
 
 # Install opt-in packages
 if [[ "$PROJECT_EDITION" != "oss" ]]; then
-  # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), whole v4.6 test matrix is supported (PHP 7.4, 8.0, 8.3)
   # ibexa/connector-qualifio is already being installed with the project
   docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --no-scripts --ansi --no-update
 fi

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -115,8 +115,8 @@ docker exec install_dependencies composer recipes:install ${DEPENDENCY_PACKAGE_N
 docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --no-scripts --ansi --no-update
 
 # Install opt-in packages
-if [[ "$PROJECT_EDITION" != "oss" ]] && [[ $PHP_IMAGE == *"8.3"* ]]; then
-  # openai-php/client requires PHP 8.1+, v4.6 test matrix has PHP 7.4, 8.0, 8.3
+if [[ "$PROJECT_EDITION" != "oss" ]]; then
+  # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), whole v4.6 test matrix is supported (PHP 7.4, 8.0, 8.3)
   # ibexa/connector-qualifio is already being installed with the project
   docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --no-scripts --ansi --no-update
 fi

--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -116,7 +116,7 @@ docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION i
 
 # Install opt-in packages
 if [[ "$PROJECT_EDITION" != "oss" ]]; then
-  # openai-php/client requires PHP 8.1+, v5.0 test matrix has PHP 8.3 only
+  # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), v5.0 test matrix has PHP 8.3 only (unaffected)
   # ibexa/connector-qualifio is already being installed with the project
   docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --no-scripts --ansi --no-update
 fi

--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -116,7 +116,6 @@ docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION i
 
 # Install opt-in packages
 if [[ "$PROJECT_EDITION" != "oss" ]]; then
-  # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), v5.0 test matrix has PHP 8.3 only (unaffected)
   # ibexa/connector-qualifio is already being installed with the project
   docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --no-scripts --ansi --no-update
 fi

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -49,7 +49,6 @@ else
     echo "> Installing dependencies for v4"
     docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi
     if [[ "$PROJECT_EDITION" != "oss" ]]; then
-      # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), whole v4.6 test matrix is supported (PHP 7.4, 8.0, 8.3)
       echo "> Installing opt-in packages"
       # ibexa/connector-qualifio is already being installed with the project
       docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -48,8 +48,8 @@ if [[ $PROJECT_VERSION == *"v3.3"* ]]; then
 else
     echo "> Installing dependencies for v4"
     docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi
-    if [[ "$PROJECT_EDITION" != "oss" ]] && [[ $PHP_IMAGE == *"8.3"* ]]; then
-      # openai-php/client requires PHP 8.1+, v4.6 test matrix has PHP 7.4, 8.0, 8.3
+    if [[ "$PROJECT_EDITION" != "oss" ]]; then
+      # openai-php/client was replaced with orhanerday/open-ai (PHP 7.4+), whole v4.6 test matrix is supported (PHP 7.4, 8.0, 8.3)
       echo "> Installing opt-in packages"
       # ibexa/connector-qualifio is already being installed with the project
       docker exec install_dependencies composer require ibexa/connector-ai:$PROJECT_VERSION ibexa/connector-openai:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi


### PR DESCRIPTION
| :ticket: Issue | IBX-8959 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/connector-openai/pull/29


#### Description:
Included AI packages in all PHP versions on v4.6 after OpenAI client change. For stable and 4.6.x-dev.

On v4.6 we have PHP 7.4, 8.0, 8.3.
On v5.0 we have PHP 8.3 only.

Follow-up to https://github.com/ibexa/ci-scripts/pull/93.

#### For QA:
Tested in https://github.com/ibexa/oss/pull/190 & https://github.com/ibexa/headless/pull/184.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
