### PR TITLE
IBX-8543: Added display database version step to prepare project scripts

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -187,9 +187,9 @@ docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/consol
 
 echo '> Display database version for debugging'
 if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
-    docker exec -it ibexa-db-1 sh -c "psql -V"
+    docker exec ibexa-db-1 sh -c "psql -V"
 else
-    docker exec -it ibexa-db-1 sh -c "mysql -V"
+    docker exec ibexa-db-1 sh -c "mysql -V"
 fi
 
 echo '> Generate GraphQL schema'

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -187,9 +187,9 @@ docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/consol
 
 echo '> Display database version for debugging'
 if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
-    psql -V
+    docker compose --env-file=.env exec -T --user www-data app sh -c "psql -V"
 else
-    mysql -V
+    docker compose --env-file=.env exec -T --user www-data app sh -c "mysql -V"
 fi
 
 echo '> Generate GraphQL schema'

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -187,7 +187,7 @@ docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/consol
 
 echo '> Display database version for debugging'
 if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
-    docker compose --env-file=.env exec -T --user www-data app sh -c "psql -V"
+    docker compose --env-file=.env exec -T --user www-data app sh -c "which psql"
 else
     docker compose --env-file=.env exec -T --user www-data app sh -c "mysql -V"
 fi

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -185,6 +185,13 @@ fi
 docker compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing"
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
+echo '> Display database version for debugging'
+if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
+    psql -V
+else
+    mysql -V
+fi
+
 echo '> Generate GraphQL schema'
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"
 

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -187,9 +187,9 @@ docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/consol
 
 echo '> Display database version for debugging'
 if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
-    docker compose --env-file=.env exec -T --user www-data app sh -c "which psql"
+    docker exec -it ibexa-db-1 sh -c "psql -V"
 else
-    docker compose --env-file=.env exec -T --user www-data app sh -c "mysql -V"
+    docker exec -it ibexa-db-1 sh -c "mysql -V"
 fi
 
 echo '> Generate GraphQL schema'

--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -185,6 +185,13 @@ fi
 docker compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing --no-interaction"
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
+echo '> Display database version for debugging'
+if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
+    docker exec ibexa-db-1 sh -c "psql -V"
+else
+    docker exec ibexa-db-1 sh -c "mysql -V"
+fi
+
 echo '> Generate GraphQL schema'
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"
 

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -87,6 +87,13 @@ fi
 docker compose --env-file=.env exec -T --user www-data app sh -c "php /scripts/wait_for_db.php; php bin/console ibexa:install --skip-indexing --no-interaction"
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:reindex"
 
+echo '> Display database version for debugging'
+if [[ "$COMPOSE_FILE" == *"db-postgresql.yml"* ]]; then
+    docker exec ibexa-db-1 sh -c "psql -V"
+else
+    docker exec ibexa-db-1 sh -c "mysql -V"
+fi
+
 echo '> Generate GraphQL schema'
 docker compose --env-file=.env exec -T --user www-data app sh -c "php bin/console ibexa:graphql:generate-schema"
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8543 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/docker/pull/36


#### Description:
Things done:
- Added step displaying database version for debugging for 4.6.x-dev, 5.0.x-dev and tags
- ~Bumped Ubuntu version in `ci.yaml` (temporarily, also covered in~ https://github.com/ibexa/ci-scripts/pull/101)

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
