### PR TITLE
IBX-8226: Removed obsolete error handler setup from installation script

### DIFF
--- a/bin/5.0.x-dev/prepare_project_edition.sh
+++ b/bin/5.0.x-dev/prepare_project_edition.sh
@@ -145,12 +145,6 @@ docker exec install_dependencies composer update --no-scripts
 # Enable FriendsOfBehat SymfonyExtension in the Behat env
 sudo sed -i "s/\['test' => true\]/\['test' => true, 'behat' => true\]/g" config/bundles.php
 
-if [[ $PHP_IMAGE == *"8.2"* ]] || [[ $PHP_IMAGE == *"8.3"* ]]; then
-    echo "> Set PHP 8.2+ Ibexa error handler to avoid deprecations"
-    docker exec install_dependencies composer config extra.runtime.error_handler "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
-    docker exec install_dependencies composer dump-autoload
-fi
-
 echo "> Display composer.json for debugging"
 cat composer.json
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8226 |
|----------------|----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/542

#### Description:
The custom error handler \Ibexa\Contracts\Core\MVC\Symfony\ErrorHandler\Php82HideDeprecationsErrorHandler was removed as part of IBX-8226.

This PR removes the conditional logic from the installation script that configured this handler for PHP 8.2 and 8.3.

No replacement is needed as deprecations are now handled via native mechanisms or are no longer suppressed by default.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
