### PR TITLE
IBX-11133: Added integrated help opt-in package to stable for v5

### DIFF
--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -71,6 +71,7 @@ else
     docker exec install_dependencies composer require ibexa/behat:$PROJECT_VERSION ibexa/docker:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi
     if [[ "$PROJECT_EDITION" != "oss" ]]; then
       docker exec install_dependencies composer require ibexa/connector-anthropic:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi
+      docker exec install_dependencies composer require ibexa/integrated-help:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi
     fi
     if [[ "$PROJECT_EDITION" == "commerce" ]]; then
       docker exec install_dependencies composer require ibexa/shopping-list:$PROJECT_VERSION --with-all-dependencies --no-scripts --ansi


### PR DESCRIPTION
| :ticket: Issue | IBX-11133 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Added integrated help opt-in package to stable for v5.

Follow-up to https://github.com/ibexa/ci-scripts/pull/113 & https://github.com/ibexa/ci-scripts/pull/130.

Discovered in test run for v5 tags, e.g. https://github.com/ibexa/headless/actions/runs/24671597626/job/72143684303.

Got missed due to the confusing fact that this package is opt-in in both v4.6 & v5.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
