### PR TITLE
IBX-11717: [4.6] Configured ignoring unsolvable advisories on PHP 7.4

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -42,6 +42,23 @@ ${PHP_IMAGE}
 echo "> Setting up website skeleton"
 composer create-project ibexa/website-skeleton:$PROJECT_VERSION . --no-install --ansi
 
+# Configure composer audit for unresolvable advisories
+docker exec install_dependencies sh -c '
+  cd /var/www
+
+  PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")"
+
+  if [ "$PHP_VERSION" = "7.4" ]; then
+    REASON="The affected version of 3rd party component is installed on PHP 7.4. There'\''s no alternative supporting PHP 7.4. Consider upgrading to PHP 8"
+
+    composer config audit.ignore --json "{
+      \"PKSA-7h5p-prw9-w5nr\": \"$REASON\",
+      \"PKSA-sf9j-1gs7-xzvx\": \"$REASON\",
+      \"PKSA-xwpn-zs9j-6wy5\": \"$REASON\"
+    }"
+  fi
+'
+
 # Add other dependencies if required
 if [ -f ${DEPENDENCY_PACKAGE_DIR}/dependencies.json ]; then
     cp ${DEPENDENCY_PACKAGE_DIR}/dependencies.json .

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -54,7 +54,24 @@ docker exec install_dependencies sh -c '
     composer config audit.ignore --json "{
       \"PKSA-7h5p-prw9-w5nr\": \"$REASON\",
       \"PKSA-sf9j-1gs7-xzvx\": \"$REASON\",
-      \"PKSA-xwpn-zs9j-6wy5\": \"$REASON\"
+      \"PKSA-xwpn-zs9j-6wy5\": \"$REASON\",
+      \"PKSA-5k7f-wvjj-jrgw\": \"$REASON\",
+      \"PKSA-sjvz-tbbr-vwth\": \"$REASON\",
+      \"PKSA-h8hf-ytnd-5t9q\": \"$REASON\",
+      \"PKSA-wwb1-81rc-pd65\": \"$REASON\",
+      \"PKSA-hgmw-wn4d-hpcy\": \"$REASON\",
+      \"PKSA-kvv6-36cr-fkzb\": \"$REASON\",
+      \"PKSA-n14z-jjjg-g8vd\": \"$REASON\",
+      \"PKSA-3mcc-k66d-pydb\": \"$REASON\",
+      \"PKSA-gw7n-z4yx-7xjt\": \"$REASON\",
+      \"PKSA-dpx1-78wg-1kqs\": \"$REASON\",
+      \"PKSA-21g2-dzjv-sky5\": \"$REASON\",
+      \"PKSA-v3kg-5xkr-pykw\": \"$REASON\",
+      \"PKSA-yhcn-xrg3-68b1\": \"$REASON\",
+      \"PKSA-2wrf-1xmk-1pky\": \"$REASON\",
+      \"PKSA-6319-ffpf-gx66\": \"$REASON\",
+      \"PKSA-n7sg-8f52-pqtf\": \"$REASON\",
+      \"PKSA-8kk8-h2xr-h5nx\": \"$REASON\"
     }"
   fi
 '

--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -71,7 +71,8 @@ docker exec install_dependencies sh -c '
       \"PKSA-2wrf-1xmk-1pky\": \"$REASON\",
       \"PKSA-6319-ffpf-gx66\": \"$REASON\",
       \"PKSA-n7sg-8f52-pqtf\": \"$REASON\",
-      \"PKSA-8kk8-h2xr-h5nx\": \"$REASON\"
+      \"PKSA-8kk8-h2xr-h5nx\": \"$REASON\",
+      \"PKSA-2rbx-bjdx-4d4d\": \"$REASON\"
     }"
   fi
 '


### PR DESCRIPTION
| :ticket: Issue | IBX-11717, IBX-11797 |
|----------------|-----------|


#### Related PRs: 

- ibexa/gh-workflows#96
- ibexa/graphql#101
- Regressions: ibexa/commerce#1819


#### Description:

This PR configures on the fly composer `audit.ignore` config.

For now, we have:


1. [3 advisories for webonyx/graphql-php](https://github.com/webonyx/graphql-php/security) package:
- [PKSA-xwpn-zs9j-6wy5](https://packagist.org/security-advisories/PKSA-xwpn-zs9j-6wy5),
- [PKSA-sf9j-1gs7-xzvx](https://packagist.org/security-advisories/PKSA-sf9j-1gs7-xzvx), 
- [PKSA-7h5p-prw9-w5nr](https://packagist.org/security-advisories/PKSA-7h5p-prw9-w5nr)

2. [17 advisories for `twig/twig`](https://github.com/twigphp/Twig/security):
- [PKSA-5k7f-wvjj-jrgw](https://packagist.org/security-advisories/PKSA-5k7f-wvjj-jrgw) 
- [PKSA-sjvz-tbbr-vwth](https://packagist.org/security-advisories/PKSA-sjvz-tbbr-vwth) 
- [PKSA-h8hf-ytnd-5t9q](https://packagist.org/security-advisories/PKSA-h8hf-ytnd-5t9q) 
- [PKSA-wwb1-81rc-pd65](https://packagist.org/security-advisories/PKSA-wwb1-81rc-pd65) 
- [PKSA-hgmw-wn4d-hpcy](https://packagist.org/security-advisories/PKSA-hgmw-wn4d-hpcy) 
- [PKSA-kvv6-36cr-fkzb](https://packagist.org/security-advisories/PKSA-kvv6-36cr-fkzb) 
- [PKSA-n14z-jjjg-g8vd](https://packagist.org/security-advisories/PKSA-n14z-jjjg-g8vd) 
- [PKSA-3mcc-k66d-pydb](https://packagist.org/security-advisories/PKSA-3mcc-k66d-pydb) 
- [PKSA-gw7n-z4yx-7xjt](https://packagist.org/security-advisories/PKSA-gw7n-z4yx-7xjt) 
- [PKSA-dpx1-78wg-1kqs](https://packagist.org/security-advisories/PKSA-dpx1-78wg-1kqs) 
- [PKSA-21g2-dzjv-sky5](https://packagist.org/security-advisories/PKSA-21g2-dzjv-sky5) 
- [PKSA-v3kg-5xkr-pykw](https://packagist.org/security-advisories/PKSA-v3kg-5xkr-pykw) 
- [PKSA-yhcn-xrg3-68b1](https://packagist.org/security-advisories/PKSA-yhcn-xrg3-68b1) 
- [PKSA-2wrf-1xmk-1pky](https://packagist.org/security-advisories/PKSA-2wrf-1xmk-1pky) 
- [PKSA-6319-ffpf-gx66](https://packagist.org/security-advisories/PKSA-6319-ffpf-gx66) 
- [PKSA-n7sg-8f52-pqtf](https://packagist.org/security-advisories/PKSA-n7sg-8f52-pqtf) 
- [PKSA-8kk8-h2xr-h5nx](https://packagist.org/security-advisories/PKSA-8kk8-h2xr-h5nx)

3. 1 advisory for `twig/intl-extra`:
- [PKSA-2rbx-bjdx-4d4d](https://packagist.org/security-advisories/PKSA-2rbx-bjdx-4d4d) 

They don't have a solution / patch for PHP 7.4 which is past EOL, however we still need to run our CI on PHP 7.4. We, of course, recommend switching to PHP 8 as soon as possible.

Without this, Browser tests ran on PHP 7.4, were installing [webonyx/graphql-php `14.x-dev`](https://github.com/ibexa/commerce/actions/runs/26011746476/job/76453882374#step:10:506) dev version due to minimum-stability. It's not possible to run Browser Tests ATM on a tagged version due to lack of installable stable candidate.

Moreover as of May 20, 2026 after `twig/twig` security release, it's no longer possible to run Browser Test (or install any package or edition for that matter) on PHP 7.4

#### For QA:

Verify the approach & verify that `webonyx/graphql-php` is being installed using tagged version - for PHP 7.4 - with known vulnerabilities, for PHP 8+ - the patched version.

Regressions: ibexa/commerce#1819.

#### Documentation:

Already documented.