### PR TITLE
IBX-11808: Configured composer audit for 3.3 nightly regressions

### DIFF
--- a/bin/4.6.x-dev/prepare_project_edition.sh
+++ b/bin/4.6.x-dev/prepare_project_edition.sh
@@ -43,60 +43,11 @@ echo "> Setting up website skeleton"
 composer create-project ibexa/website-skeleton:$PROJECT_VERSION . --no-install --ansi
 
 # Configure composer audit for unresolvable advisories
-docker exec install_dependencies bash -c '
-  cd /var/www
+echo "> Adding composer audit.ignore script, if applies"
+curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/_common/composer_audit_ignore.sh" > composer_audit_ignore.sh
+source ./composer_audit_ignore.sh
 
-  add_audit_ignores() {
-    local reason=$1
-    shift
-
-    for advisory in "$@"; do
-      composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
-    done
-  }
-
-  PHP74_ADVISORIES=(
-    PKSA-xwpn-zs9j-6wy5
-    PKSA-sf9j-1gs7-xzvx
-    PKSA-7h5p-prw9-w5nr
-  )
-
-  PHP74_PHP80_ADVISORIES=(
-    PKSA-5k7f-wvjj-jrgw
-    PKSA-sjvz-tbbr-vwth
-    PKSA-h8hf-ytnd-5t9q
-    PKSA-wwb1-81rc-pd65
-    PKSA-hgmw-wn4d-hpcy
-    PKSA-kvv6-36cr-fkzb
-    PKSA-n14z-jjjg-g8vd
-    PKSA-3mcc-k66d-pydb
-    PKSA-gw7n-z4yx-7xjt
-    PKSA-dpx1-78wg-1kqs
-    PKSA-21g2-dzjv-sky5
-    PKSA-v3kg-5xkr-pykw
-    PKSA-yhcn-xrg3-68b1
-    PKSA-2wrf-1xmk-1pky
-    PKSA-6319-ffpf-gx66
-    PKSA-n7sg-8f52-pqtf
-    PKSA-8kk8-h2xr-h5nx
-    PKSA-2rbx-bjdx-4d4d
-    PKSA-fs5b-x5k4-1h39
-  )
-
-  PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")"
-
-  if [ "$PHP_VERSION" = "7.4" ]; then
-    add_audit_ignores \
-      "The affected version of 3rd party component is installed on PHP 7.4. There is no alternative supporting PHP 7.4. Consider upgrading to PHP 8.1+" \
-      "${PHP74_ADVISORIES[@]}"
-  fi
-
-  if [ "$PHP_VERSION" = "7.4" ] || [ "$PHP_VERSION" = "8.0" ]; then
-    add_audit_ignores \
-      "The affected version of 3rd party component is installed on PHP ${PHP_VERSION}. There is no alternative supporting PHP ${PHP_VERSION}. Consider upgrading to PHP 8.1+" \
-      "${PHP74_PHP80_ADVISORIES[@]}"
-  fi
-'
+add_composer_audit_ignore_config
 
 # Add other dependencies if required
 if [ -f ${DEPENDENCY_PACKAGE_DIR}/dependencies.json ]; then

--- a/bin/^3.3.x-dev/prepare_project_edition.sh
+++ b/bin/^3.3.x-dev/prepare_project_edition.sh
@@ -110,6 +110,13 @@ if [ -f ${DEPENDENCY_PACKAGE_DIR}/dependencies.json ]; then
     fi
 fi
 
+# Configure composer audit for unresolvable advisories
+echo "> Adding composer audit.ignore script, if applies"
+curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/_common/composer_audit_ignore.sh" > composer_audit_ignore.sh
+source ./composer_audit_ignore.sh
+
+add_composer_audit_ignore_config
+
 docker exec install_dependencies composer update --ansi
 
 # Move dependency to directory available for docker volume

--- a/bin/_common/composer_audit_ignore.sh
+++ b/bin/_common/composer_audit_ignore.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+add_composer_audit_ignore_config() {
+    docker exec install_dependencies bash -c '
+      cd /var/www
+
+      add_audit_ignores() {
+        local reason=$1
+        shift
+
+        for advisory in "$@"; do
+          composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
+        done
+      }
+
+      PHP74_ADVISORIES=(
+        PKSA-xwpn-zs9j-6wy5
+        PKSA-sf9j-1gs7-xzvx
+        PKSA-7h5p-prw9-w5nr
+      )
+
+      PHP74_PHP80_ADVISORIES=(
+        PKSA-5k7f-wvjj-jrgw
+        PKSA-sjvz-tbbr-vwth
+        PKSA-h8hf-ytnd-5t9q
+        PKSA-wwb1-81rc-pd65
+        PKSA-hgmw-wn4d-hpcy
+        PKSA-kvv6-36cr-fkzb
+        PKSA-n14z-jjjg-g8vd
+        PKSA-3mcc-k66d-pydb
+        PKSA-gw7n-z4yx-7xjt
+        PKSA-dpx1-78wg-1kqs
+        PKSA-21g2-dzjv-sky5
+        PKSA-v3kg-5xkr-pykw
+        PKSA-yhcn-xrg3-68b1
+        PKSA-2wrf-1xmk-1pky
+        PKSA-6319-ffpf-gx66
+        PKSA-n7sg-8f52-pqtf
+        PKSA-8kk8-h2xr-h5nx
+        PKSA-2rbx-bjdx-4d4d
+        PKSA-fs5b-x5k4-1h39
+      )
+
+      PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")"
+
+      if [ "$PHP_VERSION" = "7.4" ]; then
+        add_audit_ignores \
+          "The affected version of 3rd party component is installed on PHP 7.4. There is no alternative supporting PHP 7.4. Consider upgrading to PHP 8.1+" \
+          "${PHP74_ADVISORIES[@]}"
+      fi
+
+      if [ "$PHP_VERSION" = "7.4" ] || [ "$PHP_VERSION" = "8.0" ]; then
+        add_audit_ignores \
+          "The affected version of 3rd party component is installed on PHP ${PHP_VERSION}. There is no alternative supporting PHP ${PHP_VERSION}. Consider upgrading to PHP 8.1+" \
+          "${PHP74_PHP80_ADVISORIES[@]}"
+      fi
+    '
+}

--- a/bin/_common/composer_audit_ignore.sh
+++ b/bin/_common/composer_audit_ignore.sh
@@ -39,6 +39,11 @@ add_composer_audit_ignore_config() {
         PKSA-8kk8-h2xr-h5nx
         PKSA-2rbx-bjdx-4d4d
         PKSA-fs5b-x5k4-1h39
+        PKSA-fbvq-z33h-r2np
+        PKSA-g9zw-qxh8-pq8w
+        PKSA-yd6k-t2gh-1m43
+        PKSA-1tmc-rt7x-12w6
+        PKSA-xx6c-6d96-db2w
       )
 
       PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")"

--- a/bin/_common/composer_audit_ignore.sh
+++ b/bin/_common/composer_audit_ignore.sh
@@ -21,7 +21,7 @@ add_composer_audit_ignore_config() {
         PKSA-7h5p-prw9-w5nr
       )
 
-      PHP74_PHP80_ADVISORIES=(
+      PHP7X_PHP80_ADVISORIES=(
         PKSA-5k7f-wvjj-jrgw
         PKSA-sjvz-tbbr-vwth
         PKSA-h8hf-ytnd-5t9q
@@ -56,10 +56,10 @@ add_composer_audit_ignore_config() {
           "${PHP74_ADVISORIES[@]}"
       fi
 
-      if [ "$PHP_VERSION" = "7.4" ] || [ "$PHP_VERSION" = "8.0" ]; then
+      if [ "$PHP_VERSION" = "7.3" ] || [ "$PHP_VERSION" = "7.4" ] || [ "$PHP_VERSION" = "8.0" ]; then
         add_audit_ignores \
           "The affected version of 3rd party component is installed on PHP ${PHP_VERSION}. There is no alternative supporting PHP ${PHP_VERSION}. Consider upgrading to PHP 8.1+" \
-          "${PHP74_PHP80_ADVISORIES[@]}"
+          "${PHP7X_PHP80_ADVISORIES[@]}"
       fi
     '
 

--- a/bin/_common/composer_audit_ignore.sh
+++ b/bin/_common/composer_audit_ignore.sh
@@ -11,6 +11,8 @@ add_composer_audit_ignore_config() {
         for advisory in "$@"; do
           composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
         done
+
+        return $?
       }
 
       PHP74_ADVISORIES=(
@@ -60,4 +62,6 @@ add_composer_audit_ignore_config() {
           "${PHP74_PHP80_ADVISORIES[@]}"
       fi
     '
+
+    return $?
 }

--- a/bin/stable/prepare_project_edition.sh
+++ b/bin/stable/prepare_project_edition.sh
@@ -38,60 +38,12 @@ if [[ $PHP_IMAGE == *"8.3"* ]]; then
     echo "> Running composer install"
     docker exec install_dependencies composer install --no-scripts --ansi
 else
-    docker exec install_dependencies bash -c '
-      cd /var/www
+    # Configure composer audit for unresolvable advisories
+    echo "> Adding composer audit.ignore script, if applies"
+    curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/_common/composer_audit_ignore.sh" > composer_audit_ignore.sh
+    source ./composer_audit_ignore.sh
 
-      add_audit_ignores() {
-        local reason=$1
-        shift
-
-        for advisory in "$@"; do
-          composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
-        done
-      }
-
-      PHP74_ADVISORIES=(
-        PKSA-xwpn-zs9j-6wy5
-        PKSA-sf9j-1gs7-xzvx
-        PKSA-7h5p-prw9-w5nr
-      )
-
-      PHP74_PHP80_ADVISORIES=(
-        PKSA-5k7f-wvjj-jrgw
-        PKSA-sjvz-tbbr-vwth
-        PKSA-h8hf-ytnd-5t9q
-        PKSA-wwb1-81rc-pd65
-        PKSA-hgmw-wn4d-hpcy
-        PKSA-kvv6-36cr-fkzb
-        PKSA-n14z-jjjg-g8vd
-        PKSA-3mcc-k66d-pydb
-        PKSA-gw7n-z4yx-7xjt
-        PKSA-dpx1-78wg-1kqs
-        PKSA-21g2-dzjv-sky5
-        PKSA-v3kg-5xkr-pykw
-        PKSA-yhcn-xrg3-68b1
-        PKSA-2wrf-1xmk-1pky
-        PKSA-6319-ffpf-gx66
-        PKSA-n7sg-8f52-pqtf
-        PKSA-8kk8-h2xr-h5nx
-        PKSA-2rbx-bjdx-4d4d
-        PKSA-fs5b-x5k4-1h39
-      )
-
-      PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;")"
-
-      if [ "$PHP_VERSION" = "7.4" ]; then
-        add_audit_ignores \
-          "The affected version of 3rd party component is installed on PHP 7.4. There is no alternative supporting PHP 7.4. Consider upgrading to PHP 8.1+" \
-          "${PHP74_ADVISORIES[@]}"
-      fi
-
-      if [ "$PHP_VERSION" = "7.4" ] || [ "$PHP_VERSION" = "8.0" ]; then
-        add_audit_ignores \
-          "The affected version of 3rd party component is installed on PHP ${PHP_VERSION}. There is no alternative supporting PHP ${PHP_VERSION}. Consider upgrading to PHP 8.1+" \
-          "${PHP74_PHP80_ADVISORIES[@]}"
-      fi
-    '
+    add_composer_audit_ignore_config
 
     echo "> Running composer update"
     docker exec install_dependencies composer update --no-scripts --ansi


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-11808, IBX-11825 |
|----------------|-----------|


#### Related PRs:
- #137
- #138
- ibexa/commerce#1836
- ibexa/commerce#1837
- ibexa/gh-workflows#102

#### Description:

1. Extracted composer audit ignore logic from the previous PRs and ibexa/ci-scripts@ec784284ac445caa3385047ffb79f742edf0d4e9 release-time hotfix to a common function.
Browser Tests download `prepare_project_edition.sh` script on-the-fly, so using normal bash include is not possible. Instead, downloading it via curl the same way as Browser Tests are doing.

2. Resolved also IBX-11825 while at it - there are 5 new advisories to be added.

#### For QA:

Review.

Regression:
- :green_circle: 3.3 https://github.com/ibexa/commerce/pull/1836
- :black_heart: 4.6 https://github.com/ibexa/commerce/pull/1837

#### Documentation:
No documentation required.